### PR TITLE
feat(skills): add workspace-monitor for runtime log and build observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ cognitive-core/                         Your project after install:
 | pre-commit | manual | Pre-commit validation checks |
 | fitness | manual | Codebase fitness scoring |
 | project-status | manual | Project status dashboard |
+| workspace-monitor | manual | Proactive log, test, and build monitoring |
 | workflow-analysis | manual | Workflow and process analysis |
 | test-scaffold | manual | Test file generation from source |
 | tech-intel | yes | Technology intelligence and research |

--- a/cognitive-core.conf.example
+++ b/cognitive-core.conf.example
@@ -52,9 +52,10 @@ CC_SPECIALIST_MODEL="sonnet"
 
 # ===== SKILLS =====
 # Which skills to install (space-separated)
-# Options: session-resume session-sync code-review pre-commit fitness
-#          project-status workflow-analysis test-scaffold tech-intel
-CC_SKILLS="session-resume code-review pre-commit fitness project-status"
+# Options: session-resume session-sync skill-sync code-review pre-commit fitness
+#          project-status project-board acceptance-verification workflow-analysis
+#          test-scaffold tech-intel workspace-monitor ctf-pentesting security-baseline
+CC_SKILLS="session-resume skill-sync code-review pre-commit fitness project-status"
 
 # ===== HOOKS =====
 # Which hooks to enable (space-separated)
@@ -130,6 +131,25 @@ CC_UPDATE_CHECK_INTERVAL="7"
 CC_AGENT_TEAMS="false"
 # MCP servers (space-separated): context7
 CC_MCP_SERVERS="context7"
+
+# ===== WORKSPACE MONITOR =====
+# Log directories to scan (space-separated, relative to project root)
+CC_MONITOR_LOG_DIRS="logs"
+# Test result directories (space-separated, relative to project root)
+CC_MONITOR_TEST_DIRS="test-results"
+# Build artifact directories (space-separated, relative to project root)
+CC_MONITOR_BUILD_DIRS="target dist build"
+# Additional error regex (pipe-separated, appended to language defaults)
+CC_MONITOR_EXTRA_PATTERNS=""
+# Default time window for monitoring
+CC_MONITOR_SINCE="24h"
+# Report output directory (relative to project root)
+CC_MONITOR_REPORT_DIR="${CC_SESSION_DOCS_DIR:-docs}/monitor-reports"
+# Max log file size before alerting (bytes, default 100MB)
+CC_MONITOR_MAX_LOG_SIZE="104857600"
+# Workspace mode: additional project directories to scan (absolute paths, space-separated)
+# Leave empty for single-project mode (default)
+CC_WORKSPACE_PROJECTS=""
 
 # ===== CONTEXT MANAGEMENT =====
 # Enable weekly cleanup cron: true|false

--- a/core/skills/workspace-monitor/SKILL.md
+++ b/core/skills/workspace-monitor/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: workspace-monitor
+description: Proactive log and build monitoring. Scans application logs, test results, build output, and CI artifacts with smart filtering to detect issues before users report them. Language-aware via CC_LANGUAGE — adapts error patterns per stack.
+user-invocable: true
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Grep, Glob
+argument-hint: "--errors-only | --since=1h | --build | --tests | --runtime | --all"
+---
+
+# Workspace Monitor — Proactive Log and Build Intelligence
+
+Scans application logs, test results, build output, and CI artifacts for the
+current project. Uses smart filtering to detect errors, warnings, stack traces,
+and anomalies. Language-aware — adapts scanning patterns based on `CC_LANGUAGE`
+from `cognitive-core.conf`.
+
+Operates in two modes:
+- **Single-project** (default): Scans `CC_PROJECT_DIR` only
+- **Workspace** (opt-in): If `CC_WORKSPACE_PROJECTS` is defined, scans multiple project directories
+
+## Arguments
+
+- `$ARGUMENTS` — options:
+  - `--errors-only` — only show ERROR/FATAL level entries
+  - `--since=1h|6h|24h|7d` — time window (default: `CC_MONITOR_SINCE` or `24h`)
+  - `--build` — focus on build/compile output
+  - `--tests` — focus on test results
+  - `--runtime` — focus on application runtime logs
+  - `--tail` — show last N lines of active logs
+  - `--all` — scan all categories (default behavior)
+
+## Configuration
+
+From `cognitive-core.conf`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CC_LANGUAGE` | — | Determines default error patterns and log conventions |
+| `CC_MONITOR_LOG_DIRS` | `logs` | Log directories to scan (space-separated, relative to project root) |
+| `CC_MONITOR_TEST_DIRS` | `test-results` | Test result directories (space-separated, relative) |
+| `CC_MONITOR_BUILD_DIRS` | `target dist build` | Build artifact directories (space-separated, relative) |
+| `CC_MONITOR_EXTRA_PATTERNS` | — | Additional error regex (pipe-separated, appended to language defaults) |
+| `CC_MONITOR_SINCE` | `24h` | Default time window |
+| `CC_MONITOR_REPORT_DIR` | `${CC_SESSION_DOCS_DIR}/monitor-reports` | Report output directory |
+| `CC_MONITOR_MAX_LOG_SIZE` | `104857600` | Max log file size (bytes) before alerting (100MB) |
+| `CC_WORKSPACE_PROJECTS` | — | Optional: additional project directories for multi-project scanning (absolute paths, space-separated) |
+
+## Live Context (auto-injected)
+
+### Active Log Files
+!`for dir in ${CC_MONITOR_LOG_DIRS:-logs}; do [ -d "${dir}" ] && find "${dir}" -name "*.log" -mtime -1 2>/dev/null | head -5; done`
+
+### Recent Test Results
+!`for dir in ${CC_MONITOR_TEST_DIRS:-test-results}; do ls -lt "${dir}"/*.xml 2>/dev/null | head -3; ls -lt "${dir}"/*.tap 2>/dev/null | head -3; done`
+
+### Log File Sizes
+!`for dir in ${CC_MONITOR_LOG_DIRS:-logs}; do [ -d "${dir}" ] && ls -lh "${dir}"/*.log 2>/dev/null; done`
+
+### Build Artifacts
+!`for dir in ${CC_MONITOR_BUILD_DIRS:-target dist build}; do [ -d "${dir}" ] && echo "${dir}: exists ($(find "${dir}" -maxdepth 2 \( -name "*.jar" -o -name "*.war" -o -name "*.whl" -o -name "*.tar.gz" \) 2>/dev/null | wc -l | tr -d ' ') artifacts)"; done`
+
+### cognitive-core Security Log
+!`[ -f .claude/cognitive-core/security.log ] && tail -10 .claude/cognitive-core/security.log 2>/dev/null || echo "No security log"`
+
+## Instructions
+
+### Step 1: Load Configuration and Patterns
+
+1. Source `cognitive-core.conf` for `CC_LANGUAGE`, `CC_MONITOR_*` variables
+2. Load language-specific monitor patterns if available:
+   - Check `language-packs/${CC_LANGUAGE}/monitor-patterns.conf` (in framework source)
+   - Or read inline patterns from `references/error-patterns.md` (in this skill directory)
+3. Merge `CC_MONITOR_EXTRA_PATTERNS` with language defaults (pipe-separated regex)
+
+### Step 2: Determine Scope
+
+- **Single-project** (default): Scan `CC_PROJECT_DIR` only
+- **Workspace mode**: If `CC_WORKSPACE_PROJECTS` is defined, scan each listed directory
+- Apply `$ARGUMENTS` to select categories: `--build`, `--tests`, `--runtime`, or `--all`
+
+### Step 3: Discover Log Files
+
+For each project directory in scope:
+1. Search configured `CC_MONITOR_LOG_DIRS` for `*.log` files
+2. Search for additional log locations: `**/logs/`, `**/*.log` (limit depth to 3)
+3. Check logging configuration files based on `CC_LANGUAGE`:
+   - Perl: `logger.conf`, `environments/*.yml` (Log4perl)
+   - Java: `src/main/resources/logback*.xml`, `src/main/resources/log4j2.xml`
+   - Python: `logging.conf`, `logging.yaml`, `pyproject.toml [tool.logging]`
+   - Node: `winston.config.*`, `pino` config in `package.json`
+4. Note file sizes and last modification times
+
+### Step 4: Smart Scan — Runtime Logs
+
+If `--runtime` or `--all`:
+
+For each discovered log file:
+1. **Recency check**: Skip files not modified within the `--since` window
+2. **Error extraction**: Apply language-aware error patterns (see references/error-patterns.md)
+3. **Context capture**: For each match, capture 3 lines before and 3 after
+4. **Deduplication**: Group identical error messages, count occurrences
+5. **Severity classification**:
+   - **CRITICAL**: Unhandled exceptions, OOM, security events, data corruption indicators
+   - **ERROR**: Application errors, failed operations, connection issues
+   - **WARNING**: Deprecations, slow queries, resource pressure, high retry counts
+   - **INFO**: Notable events that aren't errors but may indicate trends
+
+### Step 5: Parse Test Results
+
+If `--tests` or `--all`:
+
+1. Find test result files in `CC_MONITOR_TEST_DIRS`:
+   - **JUnit XML**: `**/TEST-*.xml`, `**/junit.xml`, `**/surefire-reports/*.xml`
+   - **TAP**: `*.tap`, `*.t` output
+   - **pytest**: `**/pytest-report.xml`
+   - **Jest**: `**/jest-results.json`
+2. Detect format based on `CC_LANGUAGE` and file extension
+3. Parse test counts: total, passed, failed, skipped, errors
+4. Calculate pass rate per test suite
+5. If `CC_TEST_COMMAND` is set, offer to re-run for live results
+
+### Step 6: Check Build Health
+
+If `--build` or `--all`:
+
+1. Check `CC_MONITOR_BUILD_DIRS` for build artifacts
+2. Detect build system from `CC_LANGUAGE`:
+   - Java: `target/` (Maven), `build/` (Gradle) — look for `BUILD SUCCESS`/`BUILD FAILURE`
+   - Python: `dist/` (setuptools/poetry), `build/` (flit)
+   - Node: `dist/`, `build/`, `.next/` — look for bundle errors
+   - Perl: `blib/` (ExtUtils), `local/` (Carton)
+3. Check for stale builds (artifacts older than source files)
+4. Verify artifact integrity (exists and non-zero size)
+5. Look for build failure indicators in build logs
+
+### Step 7: Log Growth Analysis
+
+For all discovered log files:
+1. Check current size against `CC_MONITOR_MAX_LOG_SIZE`
+2. If a log exceeds the threshold, flag as alert
+3. Check for log rotation configuration (presence of archived logs)
+4. Flag missing rotation for large log files
+
+### Step 8: Generate Monitoring Report
+
+Save to `${CC_MONITOR_REPORT_DIR:-docs/monitor-reports}/YYYY-MM-DD-monitor.md`:
+
+```markdown
+# Monitoring Report
+
+> Generated: YYYY-MM-DD HH:MM
+> Project: [CC_PROJECT_NAME] ([CC_LANGUAGE])
+> Window: last [since]
+> Mode: [single-project | workspace (N projects)]
+
+## Alerts
+
+| Severity | Source | Message | Count | Last Seen |
+|----------|--------|---------|-------|-----------|
+| CRITICAL | [log file] | [error msg] | [N] | [timestamp] |
+| ERROR | [log file] | [error msg] | [N] | [timestamp] |
+| WARNING | [log file] | [warning msg] | [N] | [timestamp] |
+
+## Test Results
+
+| Suite | Tests | Passed | Failed | Errors | Skipped | Pass Rate |
+|-------|-------|--------|--------|--------|---------|-----------|
+| [name] | [N] | [N] | [N] | [N] | [N] | [%] |
+
+## Build Health
+
+| Directory | Last Build | Status | Artifacts | Stale? |
+|-----------|-----------|--------|-----------|--------|
+| [dir] | [time ago] | [status] | [count] | [yes/no] |
+
+## Log Growth
+
+| File | Size | Threshold | Rotation | Alert |
+|------|------|-----------|----------|-------|
+| [path] | [size] | [max] | [yes/no] | [OK/WARN] |
+
+## Error Details
+
+### [Source File]
+```
+[timestamp] [level] [context]
+  error message with stack trace
+  ... (N occurrences in window)
+```
+
+## Recommended Actions
+1. [Priority action based on findings]
+```
+
+### Step 9: Workspace Mode — Aggregate Dashboard
+
+When `CC_WORKSPACE_PROJECTS` is defined and scanning multiple projects:
+- Prefix all table rows with the project name
+- Add a "Summary by Project" section at the top
+- Aggregate alert counts across projects
+
+## Examples
+
+```
+/workspace-monitor                                   # Default: full scan, last 24h
+/workspace-monitor --errors-only --since=1h          # Errors only, last hour
+/workspace-monitor --tests                           # Test results only
+/workspace-monitor --build                           # Build health only
+/workspace-monitor --runtime --since=7d              # Runtime logs, last week
+```
+
+## See Also
+
+- `/project-status` — Development progress report (git history based)
+- `/fitness` — Codebase fitness scoring (code quality)
+- `/session-resume` — Session context recovery
+- `references/error-patterns.md` — Default error patterns by language
+- `cognitive-core.conf` — All configuration reference

--- a/core/skills/workspace-monitor/references/error-patterns.md
+++ b/core/skills/workspace-monitor/references/error-patterns.md
@@ -1,0 +1,172 @@
+# Error Patterns Reference
+
+Default error patterns used by the workspace-monitor skill. Patterns are loaded
+based on `CC_LANGUAGE` from `cognitive-core.conf`. Language packs can override
+these with `language-packs/<language>/monitor-patterns.conf`.
+
+## Universal Patterns (All Languages)
+
+These patterns apply regardless of `CC_LANGUAGE`:
+
+```
+# Severity: CRITICAL
+OutOfMemoryError|StackOverflowError|SIGKILL|SIGSEGV|core dumped
+Segmentation fault|Bus error|Killed
+
+# Severity: ERROR
+ERROR|FATAL|SEVERE|CRITICAL
+Connection refused|Connection timed out|Connection reset
+Permission denied|Access denied|Unauthorized
+Disk full|No space left on device
+
+# Severity: WARNING
+WARN|WARNING|DEPRECAT
+timeout|Timeout|TIMEOUT
+retry|Retry|retrying
+```
+
+## Perl
+
+```
+# Runtime errors
+die\b|croak\b|confess\b
+DBI.*failed|execute.*failed|prepare.*failed
+Can't locate .* in @INC
+Undefined subroutine
+Use of uninitialized value
+Deep recursion on subroutine
+Global symbol .* requires explicit package name
+
+# Test patterns (TAP format)
+not ok
+Failed test
+Looks like you failed
+Looks like you planned .* but ran
+Dubious, test returned
+```
+
+## Python
+
+```
+# Runtime errors
+Traceback \(most recent call last\)
+\w+Error:|\w+Exception:
+ImportError|ModuleNotFoundError
+KeyError|IndexError|AttributeError|TypeError|ValueError
+FileNotFoundError|PermissionError|OSError
+RuntimeError|RecursionError
+asyncio.*exception|Task was destroyed
+
+# Test patterns (pytest)
+FAILED|ERROR.*test
+ERRORS|FAILURES
+=+ FAILURES =+
+=+ ERRORS =+
+short test summary
+```
+
+## Java
+
+```
+# Runtime errors
+Exception|Caused by:
+at [a-z].*\(.*\.java:[0-9]+\)
+NullPointerException|ClassNotFoundException|ClassCastException
+NoSuchMethodException|IllegalArgumentException|IllegalStateException
+IOException|FileNotFoundException|SocketException
+OutOfMemoryError|StackOverflowError
+java\.lang\.Error
+
+# Build patterns (Maven/Gradle)
+BUILD FAILURE|BUILD SUCCESS
+COMPILATION ERROR
+Tests run:.*Failures:.*Errors:
+\[ERROR\].*Failed to execute
+\[WARNING\].*deprecated
+Could not resolve dependencies
+
+# Spring Boot specific
+ApplicationContextException|BeanCreationException
+Failed to start .* context
+Whitelabel Error Page
+```
+
+## Node.js / TypeScript
+
+```
+# Runtime errors
+TypeError|ReferenceError|SyntaxError|RangeError
+Error:|error TS[0-9]+
+Cannot find module|MODULE_NOT_FOUND
+ENOENT|EACCES|ECONNREFUSED|EADDRINUSE
+UnhandledPromiseRejection|unhandled rejection
+Maximum call stack size exceeded
+
+# Build patterns
+error TS[0-9]+:.*
+Module not found|Cannot resolve
+Failed to compile
+Build error occurred
+BREAKING CHANGE
+chunk .* exceeded
+```
+
+## Go
+
+```
+# Runtime errors
+panic:|runtime error:
+fatal error:|goroutine .* \[running\]
+index out of range|nil pointer dereference
+deadlock|all goroutines are asleep
+
+# Build patterns
+cannot find package|undefined:
+build failed|compilation failed
+```
+
+## Rust
+
+```
+# Compile/runtime errors
+error\[E[0-9]+\]:
+panicked at|thread .* panicked
+cannot find|not found in this scope
+mismatched types|expected .* found
+borrow checker|cannot borrow
+
+# Build patterns (Cargo)
+error: could not compile
+warning:.*unused
+Compiling .* failed
+```
+
+## C# / .NET
+
+```
+# Runtime errors
+System\.\w+Exception
+Unhandled exception
+NullReferenceException|ArgumentException|InvalidOperationException
+StackOverflowException|OutOfMemoryException
+
+# Build patterns (dotnet/MSBuild)
+Build FAILED|error CS[0-9]+
+error MSB[0-9]+|warning CS[0-9]+
+```
+
+## Shell / Bash
+
+```
+# Script errors
+\[ERROR\]|\[DENY\]|\[WARN\]
+command not found
+Permission denied
+No such file or directory
+syntax error|unexpected token
+FAIL|FAILED|failed
+
+# cognitive-core specific
+integrity-mismatch|guard-failure
+security-violation
+```

--- a/install.sh
+++ b/install.sh
@@ -157,7 +157,8 @@ else
     # Skills
     echo ""
     info "Available skills: session-resume session-sync skill-sync code-review pre-commit fitness"
-    info "                  project-status project-board acceptance-verification workflow-analysis test-scaffold tech-intel ctf-pentesting"
+    info "                  project-status project-board acceptance-verification workflow-analysis test-scaffold"
+    info "                  tech-intel workspace-monitor ctf-pentesting security-baseline"
     prompt_default CC_SKILLS "Skills to install" "session-resume skill-sync code-review pre-commit fitness project-status project-board acceptance-verification security-baseline"
 
     # Hooks

--- a/language-packs/java/monitor-patterns.conf
+++ b/language-packs/java/monitor-patterns.conf
@@ -1,0 +1,28 @@
+#!/bin/false
+# cognitive-core language pack: Java monitor patterns
+# Sourced by workspace-monitor skill for Java/Spring Boot/Maven projects
+
+# Log file patterns (glob, relative to project root)
+MONITOR_LOG_PATTERNS="logs/*.log logs/**/*.log"
+
+# Logging config files to discover custom log paths
+MONITOR_LOG_CONFIG="src/main/resources/logback*.xml src/main/resources/log4j2.xml src/main/resources/logging.properties"
+
+# Error regex (pipe-separated, POSIX ERE)
+MONITOR_ERROR_REGEX="Exception|Caused by:|at [a-z].*\\(.*\\.java:[0-9]+\\)|NullPointerException|ClassNotFoundException|ClassCastException|NoSuchMethodException|IllegalArgumentException|IllegalStateException|IOException|FileNotFoundException|SocketException|OutOfMemoryError|StackOverflowError|java\\.lang\\.Error|ApplicationContextException|BeanCreationException|Failed to start .* context"
+
+# Test result format: tap|junit|pytest|jest
+MONITOR_TEST_FORMAT="junit"
+
+# Test result patterns (pipe-separated)
+MONITOR_TEST_REGEX="BUILD FAILURE|BUILD SUCCESS|COMPILATION ERROR|Tests run:.*Failures:.*Errors:|\\[ERROR\\].*Failed to execute|Could not resolve dependencies"
+
+# Test result file locations (glob, relative to project root)
+MONITOR_TEST_FILES="target/surefire-reports/TEST-*.xml target/surefire-reports/*.xml"
+
+# Build artifact patterns (glob, relative to project root)
+MONITOR_BUILD_ARTIFACTS="target/*.jar target/*.war"
+
+# Build success/failure indicators
+MONITOR_BUILD_SUCCESS="BUILD SUCCESS"
+MONITOR_BUILD_FAILURE="BUILD FAILURE|COMPILATION ERROR|\\[ERROR\\]"

--- a/language-packs/node/monitor-patterns.conf
+++ b/language-packs/node/monitor-patterns.conf
@@ -1,0 +1,28 @@
+#!/bin/false
+# cognitive-core language pack: Node.js/TypeScript monitor patterns
+# Sourced by workspace-monitor skill for Node/TypeScript/React projects
+
+# Log file patterns (glob, relative to project root)
+MONITOR_LOG_PATTERNS="logs/*.log *.log"
+
+# Logging config files to discover custom log paths
+MONITOR_LOG_CONFIG="package.json"
+
+# Error regex (pipe-separated, POSIX ERE)
+MONITOR_ERROR_REGEX="TypeError|ReferenceError|SyntaxError|RangeError|Error:|error TS[0-9]+|Cannot find module|MODULE_NOT_FOUND|ENOENT|EACCES|ECONNREFUSED|EADDRINUSE|UnhandledPromiseRejection|unhandled rejection|Maximum call stack size exceeded"
+
+# Test result format: tap|junit|pytest|jest
+MONITOR_TEST_FORMAT="jest"
+
+# Test result patterns (pipe-separated)
+MONITOR_TEST_REGEX="FAIL|Tests:.*failed|Test Suites:.*failed|error TS[0-9]+:|Failed to compile|BREAKING CHANGE"
+
+# Test result file locations (glob, relative to project root)
+MONITOR_TEST_FILES="test-results/*.xml jest-results.json coverage/lcov.info"
+
+# Build artifact patterns (glob, relative to project root)
+MONITOR_BUILD_ARTIFACTS="dist/**/*.js build/**/*.js .next/**/*.js"
+
+# Build success/failure indicators
+MONITOR_BUILD_SUCCESS="Compiled successfully|Build complete"
+MONITOR_BUILD_FAILURE="Failed to compile|Build error occurred|Module not found|Cannot resolve|chunk .* exceeded"

--- a/language-packs/perl/monitor-patterns.conf
+++ b/language-packs/perl/monitor-patterns.conf
@@ -1,0 +1,28 @@
+#!/bin/false
+# cognitive-core language pack: Perl monitor patterns
+# Sourced by workspace-monitor skill for Perl/Moose/Dancer2 projects
+
+# Log file patterns (glob, relative to project root)
+MONITOR_LOG_PATTERNS="logs/*.log"
+
+# Logging config files to discover custom log paths
+MONITOR_LOG_CONFIG="logger.conf environments/*.yml"
+
+# Error regex (pipe-separated, POSIX ERE)
+MONITOR_ERROR_REGEX="die\b|croak\b|confess\b|DBI.*failed|execute.*failed|prepare.*failed|Can't locate .* in @INC|Undefined subroutine|Use of uninitialized value|Deep recursion on subroutine|Global symbol .* requires explicit package name"
+
+# Test result format: tap|junit|pytest|jest
+MONITOR_TEST_FORMAT="tap"
+
+# Test result patterns (pipe-separated)
+MONITOR_TEST_REGEX="not ok|Failed test|Looks like you failed|Looks like you planned .* but ran|Dubious, test returned"
+
+# Test result file locations (glob, relative to project root)
+MONITOR_TEST_FILES="test-results/junit.xml test-results/*.tap"
+
+# Build artifact patterns (glob, relative to project root)
+MONITOR_BUILD_ARTIFACTS=""
+
+# Build success/failure indicators
+MONITOR_BUILD_SUCCESS="All tests successful"
+MONITOR_BUILD_FAILURE="FAILED|Result: FAIL"

--- a/language-packs/python/monitor-patterns.conf
+++ b/language-packs/python/monitor-patterns.conf
@@ -1,0 +1,28 @@
+#!/bin/false
+# cognitive-core language pack: Python monitor patterns
+# Sourced by workspace-monitor skill for Python projects
+
+# Log file patterns (glob, relative to project root)
+MONITOR_LOG_PATTERNS="logs/*.log *.log"
+
+# Logging config files to discover custom log paths
+MONITOR_LOG_CONFIG="logging.conf logging.yaml pyproject.toml"
+
+# Error regex (pipe-separated, POSIX ERE)
+MONITOR_ERROR_REGEX="Traceback \\(most recent call last\\)|\\w+Error:|\\w+Exception:|ImportError|ModuleNotFoundError|KeyError|IndexError|AttributeError|TypeError|ValueError|FileNotFoundError|PermissionError|RuntimeError|RecursionError|asyncio.*exception"
+
+# Test result format: tap|junit|pytest|jest
+MONITOR_TEST_FORMAT="pytest"
+
+# Test result patterns (pipe-separated)
+MONITOR_TEST_REGEX="FAILED|ERROR.*test|ERRORS|FAILURES|=+ FAILURES =+|=+ ERRORS =+|short test summary"
+
+# Test result file locations (glob, relative to project root)
+MONITOR_TEST_FILES="test-results/*.xml pytest-report.xml"
+
+# Build artifact patterns (glob, relative to project root)
+MONITOR_BUILD_ARTIFACTS="dist/*.whl dist/*.tar.gz"
+
+# Build success/failure indicators
+MONITOR_BUILD_SUCCESS="Successfully built"
+MONITOR_BUILD_FAILURE="error:|ERROR:|Build failed|setup.py.*error"

--- a/tests/suites/08-workspace-monitor.sh
+++ b/tests/suites/08-workspace-monitor.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Test suite: Validate workspace-monitor skill
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../lib/test-helpers.sh"
+
+suite_start "08 — Workspace Monitor Skill"
+
+SKILL_DIR="${ROOT_DIR}/core/skills/workspace-monitor"
+SKILL_MD="${SKILL_DIR}/SKILL.md"
+ERROR_PATTERNS="${SKILL_DIR}/references/error-patterns.md"
+
+# ---- SKILL.md existence and structure ----
+
+assert_file_exists "SKILL.md exists" "$SKILL_MD"
+assert_file_exists "error-patterns.md exists" "$ERROR_PATTERNS"
+assert_dir_exists "references/ directory exists" "${SKILL_DIR}/references"
+
+# ---- Frontmatter validation ----
+
+has_frontmatter=false
+if head -1 "$SKILL_MD" | grep -q '^---'; then
+    if sed -n '2,$p' "$SKILL_MD" | grep -qm1 '^---'; then
+        has_frontmatter=true
+    fi
+fi
+
+if $has_frontmatter; then
+    _pass "SKILL.md has YAML frontmatter"
+else
+    _fail "SKILL.md missing YAML frontmatter"
+fi
+
+# Required frontmatter fields
+if grep -q '^name:' "$SKILL_MD"; then
+    _pass "frontmatter: name field present"
+else
+    _fail "frontmatter: name field missing"
+fi
+
+if grep -q '^description:' "$SKILL_MD"; then
+    _pass "frontmatter: description field present"
+else
+    _fail "frontmatter: description field missing"
+fi
+
+if grep -q '^user-invocable:' "$SKILL_MD"; then
+    _pass "frontmatter: user-invocable field present"
+else
+    _fail "frontmatter: user-invocable field missing"
+fi
+
+if grep -q '^allowed-tools:' "$SKILL_MD"; then
+    _pass "frontmatter: allowed-tools field present"
+else
+    _fail "frontmatter: allowed-tools field missing"
+fi
+
+# ---- No hardcoded absolute paths ----
+
+if grep -qE '/Users/|/home/[a-z]' "$SKILL_MD" 2>/dev/null; then
+    hardcoded_paths=$(grep -cE '/Users/|/home/[a-z]' "$SKILL_MD" 2>/dev/null || true)
+    _fail "SKILL.md contains ${hardcoded_paths} hardcoded absolute path(s)"
+else
+    _pass "SKILL.md has no hardcoded absolute paths"
+fi
+
+if grep -qE '/Users/|/home/[a-z]' "$ERROR_PATTERNS" 2>/dev/null; then
+    hardcoded_ref_paths=$(grep -cE '/Users/|/home/[a-z]' "$ERROR_PATTERNS" 2>/dev/null || true)
+    _fail "error-patterns.md contains ${hardcoded_ref_paths} hardcoded absolute path(s)"
+else
+    _pass "error-patterns.md has no hardcoded absolute paths"
+fi
+
+# ---- CC_* variable usage ----
+
+if grep -q 'CC_MONITOR_LOG_DIRS' "$SKILL_MD"; then
+    _pass "SKILL.md references CC_MONITOR_LOG_DIRS"
+else
+    _fail "SKILL.md missing CC_MONITOR_LOG_DIRS reference"
+fi
+
+if grep -q 'CC_MONITOR_TEST_DIRS' "$SKILL_MD"; then
+    _pass "SKILL.md references CC_MONITOR_TEST_DIRS"
+else
+    _fail "SKILL.md missing CC_MONITOR_TEST_DIRS reference"
+fi
+
+if grep -q 'CC_MONITOR_BUILD_DIRS' "$SKILL_MD"; then
+    _pass "SKILL.md references CC_MONITOR_BUILD_DIRS"
+else
+    _fail "SKILL.md missing CC_MONITOR_BUILD_DIRS reference"
+fi
+
+if grep -q 'CC_LANGUAGE' "$SKILL_MD"; then
+    _pass "SKILL.md references CC_LANGUAGE for pattern loading"
+else
+    _fail "SKILL.md missing CC_LANGUAGE reference"
+fi
+
+if grep -q 'CC_MONITOR_REPORT_DIR' "$SKILL_MD"; then
+    _pass "SKILL.md references CC_MONITOR_REPORT_DIR"
+else
+    _fail "SKILL.md missing CC_MONITOR_REPORT_DIR reference"
+fi
+
+if grep -q 'CC_WORKSPACE_PROJECTS' "$SKILL_MD"; then
+    _pass "SKILL.md references CC_WORKSPACE_PROJECTS for workspace mode"
+else
+    _fail "SKILL.md missing CC_WORKSPACE_PROJECTS reference"
+fi
+
+# ---- Required sections ----
+
+for section in "## Arguments" "## Configuration" "## Live Context" "## Instructions" "## Examples" "## See Also"; do
+    if grep -qF "$section" "$SKILL_MD"; then
+        _pass "SKILL.md has section: ${section}"
+    else
+        _fail "SKILL.md missing section: ${section}"
+    fi
+done
+
+# ---- Report template contains required sections ----
+
+for report_section in "## Alerts" "## Test Results" "## Build Health" "## Log Growth" "## Error Details" "## Recommended Actions"; do
+    if grep -qF "$report_section" "$SKILL_MD"; then
+        _pass "report template has: ${report_section}"
+    else
+        _fail "report template missing: ${report_section}"
+    fi
+done
+
+# ---- Error patterns reference covers all supported languages ----
+
+for language in "Perl" "Python" "Java" "Node" "Go" "Rust" "Shell"; do
+    if grep -qF "## ${language}" "$ERROR_PATTERNS"; then
+        _pass "error-patterns.md covers: ${language}"
+    else
+        _fail "error-patterns.md missing: ${language}"
+    fi
+done
+
+# ---- Language pack monitor-patterns.conf files ----
+
+for lang in perl python java node; do
+    pattern_file="${ROOT_DIR}/language-packs/${lang}/monitor-patterns.conf"
+    if [ -f "$pattern_file" ]; then
+        _pass "language pack: ${lang}/monitor-patterns.conf exists"
+
+        # Validate required variables in pattern file
+        for var in MONITOR_ERROR_REGEX MONITOR_TEST_FORMAT MONITOR_TEST_REGEX; do
+            if grep -q "^${var}=" "$pattern_file"; then
+                _pass "  ${lang}: ${var} defined"
+            else
+                _fail "  ${lang}: ${var} missing"
+            fi
+        done
+    else
+        _fail "language pack: ${lang}/monitor-patterns.conf not found"
+    fi
+done
+
+# ---- Config example includes CC_MONITOR_* variables ----
+
+CONF_EXAMPLE="${ROOT_DIR}/cognitive-core.conf.example"
+if [ -f "$CONF_EXAMPLE" ]; then
+    for var in CC_MONITOR_LOG_DIRS CC_MONITOR_TEST_DIRS CC_MONITOR_BUILD_DIRS CC_MONITOR_SINCE CC_MONITOR_REPORT_DIR CC_MONITOR_MAX_LOG_SIZE; do
+        if grep -q "^${var}=" "$CONF_EXAMPLE"; then
+            _pass "conf.example: ${var} defined"
+        else
+            _fail "conf.example: ${var} missing"
+        fi
+    done
+else
+    _skip "cognitive-core.conf.example not found"
+fi
+
+suite_end


### PR DESCRIPTION
## Summary

- Adds a new `workspace-monitor` skill for proactive monitoring of application logs, test results, and build artifacts
- Language-aware via language-pack extensions — adapts error patterns per stack
- Fills a gap in the framework: runtime observability (complements `project-status` for dev state and `fitness` for code quality)
- Supports single-project mode (default) and optional workspace mode via `CC_WORKSPACE_PROJECTS`

## New Files (7)

| File | Purpose |
|------|---------|
| `core/skills/workspace-monitor/SKILL.md` | Generalized skill definition — no hardcoded paths, all `CC_*` config vars |
| `core/skills/workspace-monitor/references/error-patterns.md` | Default error patterns for 8 languages (Perl, Python, Java, Node, Go, Rust, C#, Shell) |
| `language-packs/perl/monitor-patterns.conf` | Perl monitoring patterns (Log4perl, TAP, DBI errors) |
| `language-packs/python/monitor-patterns.conf` | Python monitoring patterns (Traceback, pytest, setuptools) |
| `language-packs/java/monitor-patterns.conf` | Java monitoring patterns (Logback, JUnit, Maven, Spring Boot) |
| `language-packs/node/monitor-patterns.conf` | Node.js monitoring patterns (TS errors, Jest, Webpack) |
| `tests/suites/08-workspace-monitor.sh` | 57 test assertions — frontmatter, no hardcoded paths, CC_* refs, sections, language packs |

## Modified Files (3)

| File | Change |
|------|--------|
| `cognitive-core.conf.example` | Added `CC_MONITOR_*` config section (8 new variables) |
| `README.md` | Added workspace-monitor to Skills table |
| `install.sh` | Added workspace-monitor to available skills list |

## New Config Variables

```bash
CC_MONITOR_LOG_DIRS="logs"              # Log directories to scan
CC_MONITOR_TEST_DIRS="test-results"     # Test result directories
CC_MONITOR_BUILD_DIRS="target dist build" # Build artifact directories
CC_MONITOR_EXTRA_PATTERNS=""            # Custom error regex (pipe-separated)
CC_MONITOR_SINCE="24h"                  # Default time window
CC_MONITOR_REPORT_DIR="docs/monitor-reports" # Report output
CC_MONITOR_MAX_LOG_SIZE="104857600"     # Max log size alert (100MB)
CC_WORKSPACE_PROJECTS=""                # Optional: multi-project dirs
```

## How It Complements Existing Skills

| Existing | What It Measures | workspace-monitor |
|----------|-----------------|-------------------|
| `fitness` | Code quality (lint, naming, security) | Runtime health (errors, failures) |
| `project-status` | Development state (git, commits, WIP) | Operational state (logs, builds, tests) |
| `health-check.sh` | CC context budget and integrity | Application log and build health |

## Test plan

- [x] `tests/suites/08-workspace-monitor.sh` — 57 passed, 0 failed
- [x] `tests/suites/02-skill-frontmatter.sh` — 18 passed (includes new skill)
- [ ] Manual: `./install.sh /tmp/test-project` with `CC_SKILLS` including `workspace-monitor`
- [ ] Manual: `/workspace-monitor` invocation in an installed project