### PR TITLE
feat(react,core): add E2E testing patterns from production PoC

### DIFF
--- a/core/skills/e2e-visual-regression/SKILL.md
+++ b/core/skills/e2e-visual-regression/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: e2e-visual-regression
+description: "Playwright visual regression testing — baseline management, tolerance calibration, cross-platform strategies, failure debugging. Framework-agnostic patterns proven in production."
+user-invocable: true
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Grep, Glob
+argument-hint: "update | debug | calibrate | add <page>"
+catalog_description: "Visual regression — baselines, tolerance, debugging, cross-platform."
+---
+
+# E2E Visual Regression — Playwright Screenshot Testing
+
+Manage Playwright visual regression testing: baselines, comparison, debugging,
+cross-platform strategies. Framework-agnostic — works with any web stack.
+
+## Arguments
+
+- `$ARGUMENTS`:
+  - `update` — Update baselines after intentional UI changes
+  - `debug` — Diagnose a failing visual test
+  - `calibrate` — Tune tolerance settings for stability
+  - `add <page>` — Add visual regression to a new page/workflow
+  - (none) — Show status and run visual tests
+
+## How Visual Regression Works
+
+```
+First Run:     Capture → Save as baseline           → PASS
+Subsequent:    Capture → Compare against baseline    → PASS if diff ≤ threshold
+After Change:  Capture → Compare against baseline    → FAIL if diff > threshold
+                                                     → Update baseline if intentional
+```
+
+## Recommended Settings
+
+```typescript
+await expect(page).toHaveScreenshot('name.png', {
+  maxDiffPixelRatio: 0.05,   // Max 5% of pixels may differ
+  threshold: 0.3,             // Per-pixel color sensitivity (0-1)
+  animations: 'disabled',     // Freeze CSS transitions for determinism
+});
+```
+
+### Tolerance Guide
+
+| Level | `maxDiffPixelRatio` | Use Case |
+|-------|-------------------|----------|
+| Strict | 0.01 (1%) | Static pages, no dynamic content |
+| Standard | 0.03 (3%) | Pages with minor dynamic content (badges) |
+| **Default** | **0.05 (5%)** | **Pages with timestamps, user-relative data** |
+| Relaxed | 0.10 (10%) | Pages with charts, graphs, heavy animation |
+
+### Why 5% Default (Not 1%)
+
+| Noise Source | Pixel Impact | Frequency |
+|-------------|-------------|-----------|
+| Relative timestamps ("2h ago" → "3h ago") | 1-2% | Every run |
+| Font anti-aliasing / sub-pixel rendering | 0.5-1% | Cross-platform |
+| CSS animation mid-frame | 5-50% | Without `animations: disabled` |
+| Chart/graph data-driven rendering | 2-10% | Data pages |
+
+1% tolerance causes false failures on any page with dynamic content.
+
+## Baseline Management
+
+### Storage Location
+
+```
+test-file.spec.ts-snapshots/
+  name-chromium-darwin.png          ← macOS baseline
+  name-chromium-linux.png           ← Linux/CI baseline
+  name-chromium-darwin-actual.png   ← only on failure
+  name-chromium-darwin-diff.png     ← only on failure
+```
+
+Suffix: `<name>-<browser>-<os>.png`
+
+### Update After Intentional UI Changes
+
+```bash
+# Update all baselines
+npx playwright test e2e/visual/ --update-snapshots
+
+# Update specific test
+npx playwright test e2e/visual/specific.spec.ts --update-snapshots
+
+# Commit new baselines
+git add **/*-snapshots/*.png
+git commit -m "test: update visual regression baselines after UI redesign"
+```
+
+### Cross-Platform Strategy
+
+Different platforms render fonts and anti-aliasing differently. Options:
+
+| Strategy | Pros | Cons |
+|----------|------|------|
+| Per-platform baselines (default) | Exact comparison | Must maintain multiple sets |
+| Higher tolerance (0.10) | Single baseline | May miss real regressions |
+| Docker-based CI | Consistent rendering | Setup complexity |
+| Mask dynamic regions | Focused comparison | More test code |
+
+## Before Screenshot Checklist
+
+```typescript
+// 1. Wait for SPECIFIC content (not just page load)
+await expect(page.getByText('Expected Content')).toBeVisible({ timeout: 10_000 });
+
+// 2. Wait for element count if expecting multiple items
+await expect(page.locator('.card')).toHaveCount(3, { timeout: 10_000 });
+
+// 3. Dismiss overlays (cookie consent, modals, notifications)
+const overlay = page.getByText('Dismiss');
+if (await overlay.isVisible({ timeout: 1_000 }).catch(() => false)) {
+  await overlay.click();
+  await page.waitForTimeout(300); // Wait for animation
+}
+
+// 4. Expand collapsed sections if needed
+await page.getByText('Section Header').click();
+await expect(page.getByText('Section Content')).toBeVisible();
+
+// 5. Take screenshot
+await expect(page).toHaveScreenshot('descriptive-name.png', {
+  maxDiffPixelRatio: 0.05,
+  threshold: 0.3,
+  animations: 'disabled',
+});
+```
+
+## Debugging Failures
+
+### Common Failure Patterns
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Small diff (1-3%) in text | Timestamps, counters | Increase tolerance or use `page.clock` |
+| Scattered tiny diffs | Font rendering | Increase `threshold`, pin browser version |
+| Large diff in one area | Animation captured | `animations: 'disabled'`, explicit waits |
+| Spinner in screenshot | Loading state captured | Wait for content, not just page load |
+| Pass locally, fail CI | Platform rendering | Per-platform baselines or Docker |
+| Diff only in header/footer | Dynamic elements (time, user) | Mask region or freeze clock |
+
+### Debug Commands
+
+```bash
+# Run with HTML report (shows visual diffs)
+npx playwright test e2e/visual/ --reporter=html
+npx playwright show-report
+
+# Run headed (watch test execute)
+npx playwright test e2e/visual/ --headed
+
+# Run with trace (step-by-step replay with screenshots)
+npx playwright test e2e/visual/ --trace on
+
+# Debug mode (pause at each step)
+npx playwright test e2e/visual/ --debug
+
+# Interactive UI mode (timeline, DOM inspector)
+npx playwright test --ui
+```
+
+### Analyzing Failure Artifacts
+
+On failure, Playwright creates three files in the snapshots directory:
+
+| File | Contents |
+|------|----------|
+| `name-expected.png` | The baseline (what we expected) |
+| `name-actual.png` | What was captured this run |
+| `name-diff.png` | Pixel difference overlay (red = changed pixels) |
+
+Open the HTML report (`npx playwright show-report`) for side-by-side comparison
+with zoom and overlay toggle.
+
+## Clock Control for Deterministic Timestamps
+
+```typescript
+// Freeze time for entire test
+test.use({
+  // This affects the page's Date constructor
+});
+
+// Or per-test:
+await page.clock.setFixedTime(new Date('2026-03-10T12:00:00Z'));
+await page.goto('/');
+// All timestamps will show consistent values
+```
+
+## Masking Dynamic Regions
+
+```typescript
+await expect(page).toHaveScreenshot('page.png', {
+  maxDiffPixelRatio: 0.05,
+  mask: [
+    page.locator('.timestamp'),  // Ignore timestamp areas
+    page.locator('.user-avatar'), // Ignore user-specific content
+  ],
+});
+```
+
+## CI Integration
+
+### GitHub Actions Example
+
+```yaml
+- name: Run visual regression tests
+  run: |
+    cd lts-portal
+    npx playwright install chromium
+    npx playwright test e2e/visual/
+  env:
+    CI: true
+
+- name: Upload test artifacts on failure
+  if: failure()
+  uses: actions/upload-artifact@v4
+  with:
+    name: visual-regression-report
+    path: lts-portal/test-results/
+    retention-days: 7
+```
+
+### Baseline Commit Strategy
+
+- Baselines are checked into git (they ARE the source of truth)
+- Review baseline changes in PRs (GitHub renders PNG diffs)
+- Never auto-update baselines in CI — always require human review
+- Consider a separate `baseline-update` CI job that creates a PR
+
+## Workflow
+
+### On `update`
+
+```bash
+echo "Updating visual regression baselines..."
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+# Find Playwright config
+CONFIG=$(find . -name "playwright.config.ts" -not -path "*/node_modules/*" | head -1)
+if [ -z "$CONFIG" ]; then
+  echo "No playwright.config.ts found"
+  exit 1
+fi
+
+DIR=$(dirname "$CONFIG")
+cd "$DIR"
+
+# Run with update flag
+npx playwright test e2e/visual/ --update-snapshots
+
+echo "Baselines updated. Review changes with: git diff --stat"
+echo "Commit with: git add **/*-snapshots/*.png"
+```
+
+### On `debug`
+
+1. Check for recent failure artifacts (`*-actual.png`, `*-diff.png`)
+2. Show the diff image path
+3. Suggest tolerance adjustments based on diff percentage
+4. Check for common causes (animations, loading states, timestamps)
+
+### On `calibrate`
+
+1. Run visual tests 5 times consecutively
+2. Measure max pixel diff between runs
+3. Recommend tolerance = measured max + 2% safety margin
+4. Show which areas cause the most variance

--- a/language-packs/react/compact-rules.md
+++ b/language-packs/react/compact-rules.md
@@ -10,3 +10,5 @@
 8. **Test Colocation**: Place `*.test.tsx` files next to their source component, not in a separate `__tests__` directory.
 9. **Error Boundaries + Suspense**: Every async data boundary needs both `<ErrorBoundary>` and `<Suspense>`. Never let errors propagate unhandled.
 10. **Accessibility**: All interactive elements must be keyboard-navigable. Use semantic HTML. Run eslint-plugin-jsx-a11y.
+11. **E2E Auth Bypass**: For Keycloak-protected apps, use two-layer bypass (addInitScript for XHR/WS + page.route for redirects). Capture PKCE nonce from localStorage.
+12. **E2E Fixture Completeness**: Apollo InMemoryCache requires `__typename` at every object level. Missing fields cause silent cascade failures across unrelated queries.

--- a/language-packs/react/skills/react-e2e-mocking/SKILL.md
+++ b/language-packs/react/skills/react-e2e-mocking/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: react-e2e-mocking
+description: "Playwright E2E patterns for React apps with Keycloak auth and Apollo Client GraphQL. Two-layer auth bypass, operation-name routing, fixture creation rules, MUI selectors. Based on production PoC."
+user-invocable: false
+allowed-tools: Read, Grep, Glob
+catalog_description: "React E2E mocking — Keycloak bypass, Apollo GraphQL fixtures, MUI selectors."
+---
+
+# React E2E Mocking — Keycloak + Apollo + MUI
+
+Proven patterns from a production PoC: fully mocked Playwright E2E tests for a
+React 18 / Keycloak / Apollo Client / MUI v5 application. Zero backend dependency,
+zero production code changes.
+
+## Architecture
+
+```
+Playwright Test
+  ├── Auth Bypass
+  │   ├── Layer 1: addInitScript()    → XHR/WebSocket patches (browser context)
+  │   └── Layer 2: page.route()       → Network-level interception
+  ├── GraphQL Mock
+  │   └── page.route(**/api/graphql)  → Operation-name routing to JSON fixtures
+  └── Fixtures
+      └── e2e/fixtures/*.json         → Deterministic response data
+```
+
+---
+
+## 1. Keycloak Auth Bypass (Two-Layer)
+
+### Why Two Layers
+
+keycloak-js v25 uses Authorization Code + PKCE. The init flow involves:
+- XHR calls (token exchange, cookie check) — intercepted by Layer 1
+- Full-page redirects (auth endpoint) — intercepted by Layer 2
+- localStorage read/write (nonce storage) — intercepted by Layer 1
+
+Neither layer alone covers all paths.
+
+### Layer 1: addInitScript (Browser Context)
+
+Runs before any page scripts. Patches three browser APIs:
+
+**XMLHttpRequest** — intercepts keycloak-js internal HTTP calls:
+```javascript
+const OriginalXHR = window.XMLHttpRequest;
+window.XMLHttpRequest = function() {
+  const xhr = new OriginalXHR();
+  const originalOpen = xhr.open.bind(xhr);
+  const originalSend = xhr.send.bind(xhr);
+
+  let interceptUrl = '', shouldIntercept = false;
+
+  xhr.open = function(method, url, ...rest) {
+    interceptUrl = url.toString();
+    shouldIntercept = KEYCLOAK_PATTERN.test(interceptUrl);
+    return originalOpen(method, interceptUrl, ...rest);
+  };
+
+  xhr.send = function(body) {
+    if (!shouldIntercept) return originalSend(body);
+    setTimeout(() => {
+      // Build response based on URL (token endpoint, cookie check, etc.)
+      // Set readyState=4, status=200, responseText=JSON
+      // Fire readystatechange + load events
+    }, 0);
+  };
+  return xhr;
+};
+```
+
+**WebSocket** — blocks graphql-ws/subscription connections:
+```javascript
+const OriginalWebSocket = window.WebSocket;
+window.WebSocket = function(url, protocols) {
+  if (BLOCK_PATTERN.test(url)) {
+    const ws = Object.create(OriginalWebSocket.prototype);
+    Object.defineProperty(ws, 'readyState', { value: 3 }); // CLOSED
+    ws.send = ws.close = ws.addEventListener = ws.removeEventListener = () => {};
+    setTimeout(() => ws.onclose?.(new CloseEvent('close', { code: 1000 })), 10);
+    return ws;
+  }
+  return new OriginalWebSocket(url, protocols);
+};
+```
+
+**localStorage.getItem** — captures PKCE nonce:
+```javascript
+// CRITICAL: keycloak-js stores nonce in localStorage as kc-callback-{state}
+// and reads+REMOVES it in parseCallback() BEFORE the token XHR fires.
+// The token response ID token MUST include the same nonce.
+let capturedNonce = null;
+const originalGetItem = localStorage.getItem.bind(localStorage);
+localStorage.getItem = function(key) {
+  const value = originalGetItem(key);
+  if (key?.startsWith('kc-callback-') && value) {
+    try { capturedNonce = JSON.parse(value).nonce; } catch {}
+  }
+  return value;
+};
+```
+
+### Layer 2: page.route (Network Level)
+
+Handles full-page redirects that XHR patching cannot intercept.
+
+**Route priority rule**: In Playwright, routes registered LAST have HIGHEST priority.
+Register catch-all FIRST, specific routes AFTER.
+
+| Endpoint | Response |
+|----------|----------|
+| `openid-connect/auth**` | 302 → `redirect_uri#state={state}&session_state=fake&code=fake` |
+| `login-status-iframe.html**` | HTML: `postMessage('unchanged')` |
+| `3p-cookies/**` | HTML: `parent.postMessage('supported', '*')` |
+| `openid-connect/certs` | `{ keys: [] }` |
+| `openid-connect/token` | Fake token response (backup for Layer 1) |
+| `.well-known/openid-configuration` | OIDC discovery JSON |
+| `{keycloak_host}/**` | Catch-all: empty HTML |
+
+### Auth Redirect Pattern
+
+```typescript
+await page.route(`${realmUrl}/protocol/openid-connect/auth**`, async (route) => {
+  const url = new URL(route.request().url());
+  const redirectUri = url.searchParams.get('redirect_uri') || 'http://localhost:3000/';
+  const state = url.searchParams.get('state') || 'fake-state';
+  const fragment = `state=${state}&session_state=fake-session-state&code=fake-auth-code`;
+
+  await route.fulfill({
+    status: 302,
+    headers: { Location: `${redirectUri.split('#')[0]}#${fragment}` }
+  });
+});
+```
+
+### Fake JWT Requirements
+
+```javascript
+const payload = {
+  exp: now + 3600, iat: now, auth_time: now,
+  iss: realmUrl,              // Must match Keycloak realm URL
+  sub: 'fake-user-id',
+  typ: 'Bearer',              // 'ID' for id_token
+  azp: 'client-id',           // Must match Keycloak client ID
+  session_state: 'fake-session-state',
+  nonce: capturedNonce,        // CRITICAL for ID token
+  preferred_username: 'user@example.com',
+  realm_access: { roles: ['user'] },
+  resource_access: { 'client-id': { roles: ['admin'] } },
+  scope: 'openid email profile',
+};
+```
+
+### Auth Flow After Bypass
+
+```
+keycloak.init({ onLoad: 'login-required' })
+  → Layer 2 intercepts auth redirect → returns 302 with fake code
+  → Page reloads with #state=...&code=... in fragment
+  → keycloak-js calls parseCallback() → reads nonce from localStorage (Layer 1 captures it)
+  → keycloak-js POSTs to token endpoint → Layer 1 XHR mock returns tokens with nonce
+  → init() resolves → ReactKeycloakProvider fires 'onAuthSuccess'
+  → App queries GET_ME → GraphQL mock returns user fixture
+  → setAuthData() populates permission evaluator
+  → initialized=true, userAuthData=non-null → App renders
+```
+
+---
+
+## 2. Apollo GraphQL Mocking
+
+### Operation-Name Routing
+
+```typescript
+await page.route('**/api/graphql', async (route) => {
+  const body = route.request().postDataJSON();
+  const operationName = body?.operationName;
+
+  if (operationName && operationName in fixtures) {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      headers: { 'access-control-allow-origin': '*' },
+      body: JSON.stringify(fixtures[operationName])
+    });
+    return;
+  }
+
+  // CRITICAL: Fallback must return valid GraphQL response
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    headers: { 'access-control-allow-origin': '*' },
+    body: JSON.stringify({ data: null })
+  });
+});
+```
+
+### CORS Preflight Handler
+
+```typescript
+await page.route('**/api/graphql', async (route) => {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fulfill({
+      status: 204,
+      headers: {
+        'access-control-allow-origin': '*',
+        'access-control-allow-methods': 'GET, POST, OPTIONS',
+        'access-control-allow-headers': 'content-type, authorization',
+      }
+    });
+    return;
+  }
+  await route.fallback(); // Chain to main handler
+});
+```
+
+### Apollo InMemoryCache Rules
+
+| Rule | Why | Consequence If Violated |
+|------|-----|------------------------|
+| `__typename` at every object level | Cache normalization key | Silent cache corruption |
+| ALL query fields present | Cache write completeness | Other queries break (cascade) |
+| `_id` on entities | `dataIdFromObject` | Cache misses, duplicate renders |
+| Enum values exact match | Code uses strict equality | UI shows wrong state |
+
+**The cascade failure pattern**: Missing field in Query A → partial cache write →
+Query B reads same entity from corrupted cache → blank page with NO visible error.
+
+Example: Missing `UserMessagesCount.all` broke the machines list page.
+
+### Background Operations
+
+Apps fire background queries on every page load. Common ones to mock:
+
+| Operation | Critical Fields |
+|-----------|----------------|
+| `SystemNotifications` | `items: [], page: { totalElements, totalPages, ... }` |
+| `UserMessagesCount` | ALL count fields (unread, all, unreadErrors, ...) |
+| `PropertiesPrecisionSettings` | `measurementProperties: [], modelProperties: [], defaults: []` |
+| `TechnicalUnits` | `technicalUnits: []` |
+
+**Discovery**: Run test, check console for `[graphql-mock] No fixture for operation: "X"`.
+
+---
+
+## 3. Fixture Creation Checklist
+
+- [ ] `__typename` at EVERY object level
+- [ ] ALL fields from the GraphQL query included
+- [ ] Deterministic IDs (`entity-e2e-001`, `entity-e2e-002`)
+- [ ] Check source for `!.` non-null assertions on nullable fields — provide values
+- [ ] User state matches expected enum value (e.g., `"VALID"` not `"ACTIVE"`)
+- [ ] Permissions use format expected by evaluator (shiro-trie: `accessLevel: "*"` for admin)
+- [ ] `ownerId` matches `company._id` (mapped to `tenantId` internally)
+- [ ] Test incrementally — add one fixture, run, check console errors
+
+---
+
+## 4. MUI Component Selectors (Stability Ranked)
+
+| Priority | Selector | Example | Notes |
+|----------|----------|---------|-------|
+| 1 | ID attribute | `#machine_cell`, `#save_btn` | Most stable |
+| 2 | ARIA role + name | `getByRole('tab', { name: 'Settings' })` | Works for MUI tabs, buttons |
+| 3 | Text content | `getByText('Machine Name')` | Stable with fixture data |
+| 4 | Input value | `input[value="Current Value"]` | For MUI TextField (no name attr) |
+| 5 | Scoped element+ID | `button[id="menuItem"]` | When ID shared across elements |
+| 6 | CSS class | `[class*="MuiButton"]` | **Avoid** — breaks between builds |
+
+### MUI Pitfalls
+
+| Issue | Cause | Solution |
+|-------|-------|---------|
+| `getByLabel()` gets span not input | MUI label structure | Use `input[value="..."]` |
+| `input[name="field"]` fails | MUI TextField omits name | Use `input[value="..."]` |
+| Strict mode: 2 elements same ID | FAB + drawer share ID | Scope: `button[id="..."]` |
+| Form fields not visible | Accordion collapsed | Click section header to expand |
+| Cookie consent blocks clicks | Overlay on top | Dismiss early: `getByText('I AGREE').click()` |
+
+---
+
+## 5. Test Structure Template
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { bypassAuth } from '../mocks/auth-bypass';
+import { mockGraphQL } from '../mocks/graphql';
+
+test.describe('Feature Workflow', () => {
+  test('complete workflow', async ({ page }) => {
+    // Setup (MUST be before page.goto)
+    await bypassAuth(page);
+    await mockGraphQL(page);
+
+    // Navigate
+    await page.goto('/', { waitUntil: 'commit' });
+    await page.waitForURL(/expected-path/, { timeout: 30_000 });
+    await expect(page.locator('#app-top-bar').first()).toBeVisible({ timeout: 20_000 });
+
+    // Dismiss overlays
+    const cookie = page.getByText('I AGREE');
+    if (await cookie.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await cookie.click();
+    }
+
+    // Workflow steps + visual regression checkpoints
+    await expect(page).toHaveScreenshot('checkpoint.png', {
+      maxDiffPixelRatio: 0.05,
+      threshold: 0.3,
+      animations: 'disabled',
+    });
+  });
+});
+```
+
+---
+
+## 6. Debugging Playbook
+
+| Symptom | Likely Cause | Debug Action |
+|---------|-------------|--------------|
+| Blank page after auth | Nonce mismatch in ID token | Check localStorage capture |
+| Blank page after navigation | Missing fixture fields | Add `page.on('pageerror')` listener |
+| Component crash (TypeError) | Non-null assertion on null field | Search source for `!.` on fixture nulls |
+| Menu item not visible | Missing permission | Check `HasPermissions` component props |
+| Screenshot diff > threshold | Timestamps, animations | Increase tolerance, add `animations: 'disabled'` |
+| Unknown GraphQL operation | Background query not mocked | Check `[graphql-mock]` console logs |


### PR DESCRIPTION
## Summary

Contributes proven E2E testing patterns back to cognitive-core from a production PoC on a React 18 / Keycloak / Apollo Client / MUI v5 application.

- **New React pack skill**: `react-e2e-mocking` — two-layer Keycloak auth bypass, Apollo GraphQL operation routing, fixture creation rules, MUI selector guide
- **New core skill**: `e2e-visual-regression` — baseline management, tolerance calibration, cross-platform strategies, CI integration
- **Updated compact rules**: Added rules #11 (Keycloak bypass) and #12 (Apollo fixture completeness)

## PoC Results

| Metric | Value |
|--------|-------|
| Workflow steps tested | 11 |
| Visual regression checkpoints | 4 |
| GraphQL operations mocked | 15+ |
| Test execution time | ~7-10 seconds |
| Production code changes | 0 |
| Total effort | ~25 hours |

## Key Discoveries Codified

1. **Keycloak nonce synchronization**: keycloak-js v25 stores PKCE nonce in localStorage as `kc-callback-{state}`. Must capture via `localStorage.getItem` interception and echo in ID token.
2. **Playwright route priority**: Last registered = highest priority. Catch-all must be registered FIRST.
3. **Apollo cache cascade failure**: Missing field in one fixture silently breaks unrelated queries via cache normalization corruption.
4. **Visual regression tolerance**: 5% `maxDiffPixelRatio` + 0.3 `threshold` is the sweet spot for pages with timestamps and anti-aliasing.

## Files

- `language-packs/react/skills/react-e2e-mocking/SKILL.md` (330 lines)
- `core/skills/e2e-visual-regression/SKILL.md` (270 lines)
- `language-packs/react/compact-rules.md` (+2 rules)

## Test plan

- [ ] Verify skill format matches existing skills (YAML frontmatter + Markdown)
- [ ] Verify no conflicts with existing react-testing skill
- [ ] Test install.sh picks up new skills for `CC_LANGUAGE=react`