### PR TITLE
feat: add _cc_rg() ripgrep wrapper with grep fallback (#134)

### DIFF
--- a/language-packs/_common.sh
+++ b/language-packs/_common.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# cognitive-core language pack shared utilities
+# Source this from fitness-checks.sh for common functions.
+
+# Recursive grep using ripgrep when available, falling back to grep -r.
+# Usage: _cc_rg [--all] [flags] "pattern" [path]
+#   --all   Search all files including gitignored (passes --no-ignore to rg)
+# Detects rg once per session and caches the result.
+if [ -z "${_CC_HAS_RG+x}" ]; then
+    command -v rg &>/dev/null && _CC_HAS_RG=1 || _CC_HAS_RG=0
+fi
+
+_cc_rg() {
+    local use_no_ignore=false
+    local rg_args=("--no-heading" "--color=never")
+    local grep_args=()
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --all)       use_no_ignore=true; shift ;;
+            -r|-R)       grep_args+=("$1"); shift ;;
+            -E)          grep_args+=("$1"); shift ;;
+            --include=*) rg_args+=("-g" "${1#--include=}"); grep_args+=("$1"); shift ;;
+            --include)   shift; rg_args+=("-g" "$1"); grep_args+=("--include=$1"); shift ;;
+            --exclude=*) rg_args+=("-g" "!${1#--exclude=}"); grep_args+=("$1"); shift ;;
+            --exclude)   shift; rg_args+=("-g" "!$1"); grep_args+=("--exclude=$1"); shift ;;
+            *)           rg_args+=("$1"); grep_args+=("$1"); shift ;;
+        esac
+    done
+
+    [ "$use_no_ignore" = true ] && rg_args+=("--no-ignore")
+
+    if [ "$_CC_HAS_RG" -eq 1 ]; then
+        # Translate BRE escapes to ERE/Rust regex: \| → |, \( → (, \) → )
+        local translated=()
+        for arg in "${rg_args[@]}"; do
+            arg="${arg//\\|/|}"
+            arg="${arg//\\(/(}"
+            arg="${arg//\\)/)"
+            translated+=("$arg")
+        done
+        rg "${translated[@]}"
+    else
+        grep -r "${grep_args[@]}"
+    fi
+}

--- a/language-packs/angular/fitness-checks.sh
+++ b/language-packs/angular/fitness-checks.sh
@@ -4,6 +4,11 @@
 # Checks Angular-specific quality patterns and legacy anti-patterns.
 set -u
 
+# Source shared utilities for _cc_rg (ripgrep with grep fallback)
+_CC_COMMON="$(cd "$(dirname "$0")/.." && pwd)/_common.sh"
+# shellcheck disable=SC1090
+[ -f "$_CC_COMMON" ] && source "$_CC_COMMON"
+
 PROJECT_DIR="${1:-.}"
 SRC_DIR="$PROJECT_DIR/src"
 [ ! -d "$SRC_DIR" ] && SRC_DIR="$PROJECT_DIR"
@@ -25,11 +30,11 @@ add_check() {
 # === TYPE SAFETY CHECKS ===
 
 # --- Check 1: No 'any' type usage ---
-ANY_COUNT=$(grep -rn ': any\b\|<any>\|as any' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
+ANY_COUNT=$(_cc_rg -n ': any\b\|<any>\|as any' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
 add_check "No 'any' type" "$( [ "$ANY_COUNT" -le 3 ] && echo 1 || echo 0 )" "${ANY_COUNT} any usages"
 
 # --- Check 2: No @ts-ignore without explanation ---
-TS_IGNORE=$(grep -rn '@ts-ignore\|@ts-nocheck' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+TS_IGNORE=$(_cc_rg -n '@ts-ignore\|@ts-nocheck' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 add_check "No @ts-ignore/@ts-nocheck" "$( [ "$TS_IGNORE" -eq 0 ] && echo 1 || echo 0 )" "${TS_IGNORE} suppressions"
 
 # --- Check 3: TypeScript strict mode enabled ---
@@ -44,12 +49,12 @@ fi
 # === ANGULAR PATTERN CHECKS ===
 
 # --- Check 4: No NgModules in feature code ---
-NGMODULE_COUNT=$(grep -rn '@NgModule' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v 'app\.module\.ts' | grep -v 'app\.config\.ts' | wc -l | tr -d ' ')
+NGMODULE_COUNT=$(_cc_rg -n '@NgModule' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v 'app\.module\.ts' | grep -v 'app\.config\.ts' | wc -l | tr -d ' ')
 add_check "No NgModules in features" "$( [ "$NGMODULE_COUNT" -le 1 ] && echo 1 || echo 0 )" "${NGMODULE_COUNT} NgModule declarations"
 
 # --- Check 5: Standalone components adopted ---
-STANDALONE_COUNT=$(grep -rn 'standalone:[[:space:]]*true' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
-COMPONENT_COUNT=$(grep -rn '@Component' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+STANDALONE_COUNT=$(_cc_rg -n 'standalone:[[:space:]]*true' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+COMPONENT_COUNT=$(_cc_rg -n '@Component' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 if [ "$COMPONENT_COUNT" -gt 0 ]; then
     STANDALONE_PERCENT=$(( (STANDALONE_COUNT * 100) / COMPONENT_COUNT ))
 else
@@ -59,12 +64,12 @@ fi
 add_check "Standalone components >80%" "$( [ "$STANDALONE_PERCENT" -ge 80 ] || [ "$NGMODULE_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${STANDALONE_PERCENT}% standalone (${STANDALONE_COUNT}/${COMPONENT_COUNT})"
 
 # --- Check 6: Built-in control flow (no legacy structural directives) ---
-LEGACY_DIRECTIVES=$(grep -rn '\*ngIf\|\*ngFor\|\*ngSwitch' "$SRC_DIR" --include="*.ts" --include="*.html" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+LEGACY_DIRECTIVES=$(_cc_rg -n '\*ngIf\|\*ngFor\|\*ngSwitch' "$SRC_DIR" --include="*.ts" --include="*.html" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 add_check "Built-in control flow (@if/@for)" "$( [ "$LEGACY_DIRECTIVES" -le 5 ] && echo 1 || echo 0 )" "${LEGACY_DIRECTIVES} legacy directives"
 
 # --- Check 7: Signals over decorators ---
-SIGNAL_API=$(grep -rn 'signal(\|computed(\|input(\|input\.required(\|output(\|model(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
-DECORATOR_API=$(grep -rn '@Input(\|@Output(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
+SIGNAL_API=$(_cc_rg -n 'signal(\|computed(\|input(\|input\.required(\|output(\|model(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
+DECORATOR_API=$(_cc_rg -n '@Input(\|@Output(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
 TOTAL_IO=$((SIGNAL_API + DECORATOR_API))
 if [ "$TOTAL_IO" -gt 0 ]; then
     SIGNAL_PERCENT=$(( (SIGNAL_API * 100) / TOTAL_IO ))
@@ -74,8 +79,8 @@ fi
 add_check "Signals over decorators >50%" "$( [ "$SIGNAL_PERCENT" -ge 50 ] && echo 1 || echo 0 )" "${SIGNAL_PERCENT}% signals (${SIGNAL_API} signal/${DECORATOR_API} decorator)"
 
 # --- Check 8: inject() over constructor DI ---
-INJECT_COUNT=$(grep -rn 'inject(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | grep -v 'TestBed' | wc -l | tr -d ' ')
-CONSTRUCTOR_DI=$(grep -rn 'constructor(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
+INJECT_COUNT=$(_cc_rg -n 'inject(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | grep -v 'TestBed' | wc -l | tr -d ' ')
+CONSTRUCTOR_DI=$(_cc_rg -n 'constructor(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
 TOTAL_DI=$((INJECT_COUNT + CONSTRUCTOR_DI))
 if [ "$TOTAL_DI" -gt 0 ]; then
     INJECT_PERCENT=$(( (INJECT_COUNT * 100) / TOTAL_DI ))
@@ -85,7 +90,7 @@ fi
 add_check "inject() over constructor DI >50%" "$( [ "$INJECT_PERCENT" -ge 50 ] && echo 1 || echo 0 )" "${INJECT_PERCENT}% inject() (${INJECT_COUNT}/${TOTAL_DI})"
 
 # --- Check 9: OnPush change detection ---
-ONPUSH_COUNT=$(grep -rn 'ChangeDetectionStrategy.OnPush' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+ONPUSH_COUNT=$(_cc_rg -n 'ChangeDetectionStrategy.OnPush' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 if [ "$COMPONENT_COUNT" -gt 0 ]; then
     ONPUSH_PERCENT=$(( (ONPUSH_COUNT * 100) / COMPONENT_COUNT ))
 else
@@ -94,8 +99,8 @@ fi
 add_check "OnPush change detection >80%" "$( [ "$ONPUSH_PERCENT" -ge 80 ] && echo 1 || echo 0 )" "${ONPUSH_PERCENT}% OnPush (${ONPUSH_COUNT}/${COMPONENT_COUNT})"
 
 # --- Check 10: No manual subscribe leaks ---
-SUBSCRIBE_RAW=$(grep -rn '\.subscribe(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
-SUBSCRIBE_SAFE=$(grep -rn 'takeUntilDestroyed\|takeUntil\|firstValueFrom\|lastValueFrom\|toSignal(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
+SUBSCRIBE_RAW=$(_cc_rg -n '\.subscribe(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
+SUBSCRIBE_SAFE=$(_cc_rg -n 'takeUntilDestroyed\|takeUntil\|firstValueFrom\|lastValueFrom\|toSignal(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
 SUBSCRIBE_UNSAFE=$((SUBSCRIBE_RAW - SUBSCRIBE_SAFE))
 [ "$SUBSCRIBE_UNSAFE" -lt 0 ] && SUBSCRIBE_UNSAFE=0
 add_check "No unmanaged subscribes" "$( [ "$SUBSCRIBE_UNSAFE" -le 5 ] && echo 1 || echo 0 )" "${SUBSCRIBE_UNSAFE} unmanaged subscribes"
@@ -103,15 +108,15 @@ add_check "No unmanaged subscribes" "$( [ "$SUBSCRIBE_UNSAFE" -le 5 ] && echo 1 
 # === CODE QUALITY CHECKS ===
 
 # --- Check 11: No var usage ---
-VAR_COUNT=$(grep -rn '\bvar\s' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
+VAR_COUNT=$(_cc_rg -n '\bvar\s' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
 add_check "No var usage" "$( [ "$VAR_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${VAR_COUNT} var declarations"
 
 # --- Check 12: No console.log in production ---
-CONSOLE_COUNT=$(grep -rn 'console\.\(log\|debug\|info\)' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
+CONSOLE_COUNT=$(_cc_rg -n 'console\.\(log\|debug\|info\)' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.spec\.ts' | wc -l | tr -d ' ')
 add_check "No console.log in prod" "$( [ "$CONSOLE_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${CONSOLE_COUNT} console statements"
 
 # --- Check 13: No jQuery ---
-JQUERY=$(grep -rn '\$(\|\bjQuery\b' "$SRC_DIR" --include="*.ts" --include="*.html" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+JQUERY=$(_cc_rg -n '\$(\|\bjQuery\b' "$SRC_DIR" --include="*.ts" --include="*.html" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 add_check "No jQuery" "$( [ "$JQUERY" -eq 0 ] && echo 1 || echo 0 )" "${JQUERY} jQuery usages"
 
 # === TOOLING CHECKS ===
@@ -141,7 +146,7 @@ PROTRACTOR=${PROTRACTOR:-0}
 add_check "No Protractor (use Playwright)" "$( [ "$PROTRACTOR" -eq 0 ] && echo 1 || echo 0 )" "$([ "$PROTRACTOR" -gt 0 ] && echo 'protractor found in package.json')"
 
 # --- Check 17: No require() in TS ---
-REQUIRE_COUNT=$(grep -rn '\brequire(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
+REQUIRE_COUNT=$(_cc_rg -n '\brequire(' "$SRC_DIR" --include="*.ts" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
 add_check "ES imports (no require)" "$( [ "$REQUIRE_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${REQUIRE_COUNT} require() calls"
 
 # --- Check 18: Angular version >= 18 ---

--- a/language-packs/node/fitness-checks.sh
+++ b/language-packs/node/fitness-checks.sh
@@ -4,6 +4,11 @@
 # Checks Node.js/TypeScript-specific quality patterns.
 set -euo pipefail
 
+# Source shared utilities for _cc_rg (ripgrep with grep fallback)
+_CC_COMMON="$(cd "$(dirname "$0")/.." && pwd)/_common.sh"
+# shellcheck disable=SC1090
+[ -f "$_CC_COMMON" ] && source "$_CC_COMMON"
+
 PROJECT_DIR="${1:-.}"
 SRC_DIR="$PROJECT_DIR/src"
 [ ! -d "$SRC_DIR" ] && SRC_DIR="$PROJECT_DIR"
@@ -23,27 +28,27 @@ add_check() {
 }
 
 # --- Check 1: No var usage ---
-VAR_COUNT=$(grep -rn '\bvar\s' "$SRC_DIR" --include="*.ts" --include="*.js" --include="*.tsx" --include="*.jsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
+VAR_COUNT=$(_cc_rg -n '\bvar\s' "$SRC_DIR" --include="*.ts" --include="*.js" --include="*.tsx" --include="*.jsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
 add_check "No var usage" "$( [ "$VAR_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${VAR_COUNT} var declarations"
 
 # --- Check 2: No console.log in production code ---
-CONSOLE_COUNT=$(grep -rn 'console\.\(log\|debug\|info\)' "$SRC_DIR" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | grep -v '\.test\.' | grep -v '\.spec\.' | wc -l | tr -d ' ')
+CONSOLE_COUNT=$(_cc_rg -n 'console\.\(log\|debug\|info\)' "$SRC_DIR" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | grep -v '\.test\.' | grep -v '\.spec\.' | wc -l | tr -d ' ')
 add_check "No console.log in prod" "$( [ "$CONSOLE_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${CONSOLE_COUNT} console statements"
 
 # --- Check 3: No any type ---
-ANY_COUNT=$(grep -rn ': any\b\|<any>' "$SRC_DIR" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
+ANY_COUNT=$(_cc_rg -n ': any\b\|<any>' "$SRC_DIR" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
 add_check "No 'any' type" "$( [ "$ANY_COUNT" -le 3 ] && echo 1 || echo 0 )" "${ANY_COUNT} any usages"
 
 # --- Check 4: Async error handling ---
-UNHANDLED=$(grep -rn '\.then(' "$SRC_DIR" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | grep -v '\.catch' | wc -l | tr -d ' ')
+UNHANDLED=$(_cc_rg -n '\.then(' "$SRC_DIR" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | grep -v '\.catch' | wc -l | tr -d ' ')
 add_check "Promise error handling" "$( [ "$UNHANDLED" -le 2 ] && echo 1 || echo 0 )" "${UNHANDLED} unhandled .then() chains"
 
 # --- Check 5: No require() in TS ---
-REQUIRE_COUNT=$(grep -rn '\brequire(' "$SRC_DIR" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
+REQUIRE_COUNT=$(_cc_rg -n '\brequire(' "$SRC_DIR" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
 add_check "ES imports (no require)" "$( [ "$REQUIRE_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${REQUIRE_COUNT} require() calls"
 
 # --- Check 6: Strict equality ---
-LOOSE_EQ=$(grep -rn '[^!=]=[^=]' "$SRC_DIR" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | grep -c '==[^=]' || echo 0)
+LOOSE_EQ=$(_cc_rg -n '[^!=]=[^=]' "$SRC_DIR" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | grep -c '==[^=]' || echo 0)
 add_check "Strict equality (===)" "$( [ "$LOOSE_EQ" -le 2 ] && echo 1 || echo 0 )" "${LOOSE_EQ} loose equality checks"
 
 # Calculate score

--- a/language-packs/perl/fitness-checks.sh
+++ b/language-packs/perl/fitness-checks.sh
@@ -4,6 +4,11 @@
 # Checks Perl-specific quality patterns.
 set -euo pipefail
 
+# Source shared utilities for _cc_rg (ripgrep with grep fallback)
+_CC_COMMON="$(cd "$(dirname "$0")/.." && pwd)/_common.sh"
+# shellcheck disable=SC1090
+[ -f "$_CC_COMMON" ] && source "$_CC_COMMON"
+
 PROJECT_DIR="${1:-.}"
 TOTAL_CHECKS=0
 PASSED_CHECKS=0
@@ -43,15 +48,15 @@ done < <(find "$PROJECT_DIR/lib" -name "*.pm" -type f 2>/dev/null)
 add_check "namespace::autoclean" "$( [ "$AUTOCLEAN_MISSING" -eq 0 ] && echo 1 || echo 0 )" "${AUTOCLEAN_MISSING} Moose modules missing autoclean"
 
 # --- Check 3: No HashRefInflator ---
-HRI_COUNT=$(grep -rl 'HashRefInflator' "$PROJECT_DIR/lib" 2>/dev/null | wc -l | tr -d ' ')
+HRI_COUNT=$(_cc_rg -l 'HashRefInflator' "$PROJECT_DIR/lib" 2>/dev/null | wc -l | tr -d ' ')
 add_check "No HashRefInflator" "$( [ "$HRI_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${HRI_COUNT} files use HashRefInflator"
 
 # --- Check 4: Safe DateTime usage ---
-NOW_STRING_COUNT=$(grep -rn "now()" "$PROJECT_DIR/lib" --include="*.pm" 2>/dev/null | grep -v 'DateTime->now' | grep -c 'now()' || echo 0)
+NOW_STRING_COUNT=$(_cc_rg -n "now()" "$PROJECT_DIR/lib" --include="*.pm" 2>/dev/null | grep -v 'DateTime->now' | grep -c 'now()' || echo 0)
 add_check "Safe DateTime (no now() strings)" "$( [ "$NOW_STRING_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${NOW_STRING_COUNT} unsafe now() calls"
 
 # --- Check 5: No bare eval ---
-EVAL_COUNT=$(grep -rn '\beval\s*{' "$PROJECT_DIR/lib" --include="*.pm" 2>/dev/null | grep -v 'Try::Tiny' | wc -l | tr -d ' ')
+EVAL_COUNT=$(_cc_rg -n '\beval\s*{' "$PROJECT_DIR/lib" --include="*.pm" 2>/dev/null | grep -v 'Try::Tiny' | wc -l | tr -d ' ')
 add_check "No bare eval (use Try::Tiny)" "$( [ "$EVAL_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${EVAL_COUNT} bare eval blocks"
 
 # --- Check 6: strict/warnings ---

--- a/language-packs/python/fitness-checks.sh
+++ b/language-packs/python/fitness-checks.sh
@@ -4,6 +4,11 @@
 # Checks Python-specific quality patterns.
 set -euo pipefail
 
+# Source shared utilities for _cc_rg (ripgrep with grep fallback)
+_CC_COMMON="$(cd "$(dirname "$0")/.." && pwd)/_common.sh"
+# shellcheck disable=SC1090
+[ -f "$_CC_COMMON" ] && source "$_CC_COMMON"
+
 PROJECT_DIR="${1:-.}"
 SRC_DIR="$PROJECT_DIR/src"
 [ ! -d "$SRC_DIR" ] && SRC_DIR="$PROJECT_DIR"
@@ -23,8 +28,8 @@ add_check() {
 }
 
 # --- Check 1: Type hints in function definitions ---
-FUNC_COUNT=$(grep -rn 'def ' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
-TYPED_COUNT=$(grep -rn 'def .*->.*:' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
+FUNC_COUNT=$(_cc_rg -n 'def ' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
+TYPED_COUNT=$(_cc_rg -n 'def .*->.*:' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
 if [ "$FUNC_COUNT" -gt 0 ]; then
     RATIO=$(( (TYPED_COUNT * 100) / FUNC_COUNT ))
     add_check "Type hints on functions" "$( [ "$RATIO" -ge 70 ] && echo 1 || echo 0 )" "${TYPED_COUNT}/${FUNC_COUNT} typed (${RATIO}%)"
@@ -33,15 +38,15 @@ else
 fi
 
 # --- Check 2: No bare except ---
-BARE_EXCEPT=$(grep -rn 'except:' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
+BARE_EXCEPT=$(_cc_rg -n 'except:' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
 add_check "No bare except" "$( [ "$BARE_EXCEPT" -eq 0 ] && echo 1 || echo 0 )" "${BARE_EXCEPT} bare except blocks"
 
 # --- Check 3: No os.path usage (prefer pathlib) ---
-OSPATH_COUNT=$(grep -rn 'os\.path\.' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
+OSPATH_COUNT=$(_cc_rg -n 'os\.path\.' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
 add_check "Pathlib over os.path" "$( [ "$OSPATH_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${OSPATH_COUNT} os.path usages"
 
 # --- Check 4: No mutable default arguments ---
-MUTABLE_DEFAULTS=$(grep -rn 'def .*=\s*\[\]\|def .*=\s*{}\|def .*=\s*set()' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
+MUTABLE_DEFAULTS=$(_cc_rg -n 'def .*=\s*\[\]\|def .*=\s*{}\|def .*=\s*set()' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
 add_check "No mutable default args" "$( [ "$MUTABLE_DEFAULTS" -eq 0 ] && echo 1 || echo 0 )" "${MUTABLE_DEFAULTS} mutable defaults"
 
 # --- Check 5: Import ordering (ruff isort) ---
@@ -52,7 +57,7 @@ fi
 add_check "Import ordering (isort)" "$( [ "$IMPORT_ISSUES" -eq 0 ] && echo 1 || echo 0 )" "${IMPORT_ISSUES} import issues"
 
 # --- Check 6: Pydantic v2 style (no class Config:) ---
-OLD_PYDANTIC=$(grep -rn 'class Config:' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | grep -v 'pydantic_settings\|BaseSettings' | wc -l | tr -d ' ')
+OLD_PYDANTIC=$(_cc_rg -n 'class Config:' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | grep -v 'pydantic_settings\|BaseSettings' | wc -l | tr -d ' ')
 add_check "Pydantic v2 ConfigDict" "$( [ "$OLD_PYDANTIC" -eq 0 ] && echo 1 || echo 0 )" "${OLD_PYDANTIC} old-style class Config"
 
 # --- Check 7: No sync I/O in async functions ---
@@ -60,18 +65,18 @@ add_check "Pydantic v2 ConfigDict" "$( [ "$OLD_PYDANTIC" -eq 0 ] && echo 1 || ec
 SYNC_IN_ASYNC=0
 if [ "$FUNC_COUNT" -gt 0 ]; then
     # Look for requests.get/post, time.sleep, open() near async def
-    SYNC_IN_ASYNC=$(grep -rn 'requests\.\(get\|post\|put\|delete\|patch\)\|time\.sleep\b' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | grep -v '^.*#' | wc -l | tr -d ' ')
+    SYNC_IN_ASYNC=$(_cc_rg -n 'requests\.\(get\|post\|put\|delete\|patch\)\|time\.sleep\b' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | grep -v '^.*#' | wc -l | tr -d ' ')
 fi
 add_check "No sync I/O patterns" "$( [ "$SYNC_IN_ASYNC" -eq 0 ] && echo 1 || echo 0 )" "${SYNC_IN_ASYNC} sync I/O calls"
 
 # --- Check 8: No Optional[] (prefer X | None) ---
-OLD_OPTIONAL=$(grep -rn 'Optional\[' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | grep -v 'TYPE_CHECKING' | wc -l | tr -d ' ')
+OLD_OPTIONAL=$(_cc_rg -n 'Optional\[' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | grep -v 'TYPE_CHECKING' | wc -l | tr -d ' ')
 add_check "Modern union syntax (X | None)" "$( [ "$OLD_OPTIONAL" -le 3 ] && echo 1 || echo 0 )" "${OLD_OPTIONAL} Optional[] usages"
 
 # --- Check 9: Async context managers for DB sessions ---
 # Check for proper 'async with' usage (good sign of resource management)
-ASYNC_WITH=$(grep -rn 'async with' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
-ASYNC_FUNCS=$(grep -rn 'async def' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
+ASYNC_WITH=$(_cc_rg -n 'async with' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
+ASYNC_FUNCS=$(_cc_rg -n 'async def' "$SRC_DIR" --include="*.py" 2>/dev/null | grep -v '__pycache__' | wc -l | tr -d ' ')
 if [ "$ASYNC_FUNCS" -gt 5 ]; then
     add_check "Async context managers" "$( [ "$ASYNC_WITH" -gt 0 ] && echo 1 || echo 0 )" "${ASYNC_WITH} async with blocks"
 else

--- a/language-packs/react/fitness-checks.sh
+++ b/language-packs/react/fitness-checks.sh
@@ -4,6 +4,11 @@
 # Checks React-specific quality patterns and legacy anti-patterns.
 set -u
 
+# Source shared utilities for _cc_rg (ripgrep with grep fallback)
+_CC_COMMON="$(cd "$(dirname "$0")/.." && pwd)/_common.sh"
+# shellcheck disable=SC1090
+[ -f "$_CC_COMMON" ] && source "$_CC_COMMON"
+
 PROJECT_DIR="${1:-.}"
 SRC_DIR="$PROJECT_DIR/src"
 [ ! -d "$SRC_DIR" ] && SRC_DIR="$PROJECT_DIR"
@@ -25,11 +30,11 @@ add_check() {
 # === TYPE SAFETY CHECKS ===
 
 # --- Check 1: No 'any' type usage ---
-ANY_COUNT=$(grep -rn ': any\b\|<any>\|as any' "$SRC_DIR" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
+ANY_COUNT=$(_cc_rg -n ': any\b\|<any>\|as any' "$SRC_DIR" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
 add_check "No 'any' type" "$( [ "$ANY_COUNT" -le 3 ] && echo 1 || echo 0 )" "${ANY_COUNT} any usages"
 
 # --- Check 2: No @ts-ignore without explanation ---
-TS_IGNORE=$(grep -rn '@ts-ignore\|@ts-nocheck' "$SRC_DIR" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+TS_IGNORE=$(_cc_rg -n '@ts-ignore\|@ts-nocheck' "$SRC_DIR" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 add_check "No @ts-ignore/@ts-nocheck" "$( [ "$TS_IGNORE" -eq 0 ] && echo 1 || echo 0 )" "${TS_IGNORE} suppressions"
 
 # --- Check 3: TypeScript adoption (% of .tsx/.ts vs .jsx/.js) ---
@@ -46,33 +51,33 @@ add_check "TypeScript adoption >80%" "$( [ "$TS_PERCENT" -ge 80 ] && echo 1 || e
 # === REACT PATTERN CHECKS ===
 
 # --- Check 4: No class components ---
-CLASS_COMP=$(grep -rn 'extends React\.Component\|extends Component\|extends PureComponent\|extends React\.PureComponent' "$SRC_DIR" --include="*.tsx" --include="*.jsx" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+CLASS_COMP=$(_cc_rg -n 'extends React\.Component\|extends Component\|extends PureComponent\|extends React\.PureComponent' "$SRC_DIR" --include="*.tsx" --include="*.jsx" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 add_check "No class components" "$( [ "$CLASS_COMP" -eq 0 ] && echo 1 || echo 0 )" "${CLASS_COMP} class components"
 
 # --- Check 5: No PropTypes (use TypeScript interfaces instead) ---
-PROPTYPES=$(grep -rn 'PropTypes\.\|\.propTypes\s*=' "$SRC_DIR" --include="*.tsx" --include="*.jsx" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+PROPTYPES=$(_cc_rg -n 'PropTypes\.\|\.propTypes\s*=' "$SRC_DIR" --include="*.tsx" --include="*.jsx" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 add_check "No PropTypes (use TS types)" "$( [ "$PROPTYPES" -eq 0 ] && echo 1 || echo 0 )" "${PROPTYPES} PropTypes usages"
 
 # --- Check 6: No manual memoization (React Compiler handles it) ---
-MANUAL_MEMO=$(grep -rn '\buseMemo\b\|\buseCallback\b\|React\.memo(' "$SRC_DIR" --include="*.tsx" --include="*.jsx" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | grep -v '\.test\.' | grep -v '\.spec\.' | wc -l | tr -d ' ')
+MANUAL_MEMO=$(_cc_rg -n '\buseMemo\b\|\buseCallback\b\|React\.memo(' "$SRC_DIR" --include="*.tsx" --include="*.jsx" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | grep -v '\.test\.' | grep -v '\.spec\.' | wc -l | tr -d ' ')
 add_check "No manual memoization" "$( [ "$MANUAL_MEMO" -le 5 ] && echo 1 || echo 0 )" "${MANUAL_MEMO} useMemo/useCallback/React.memo"
 
 # --- Check 7: No useEffect for data fetching ---
-USE_EFFECT_FETCH=$(grep -rn 'useEffect.*fetch\|useEffect.*axios\|useEffect.*api\.' "$SRC_DIR" --include="*.tsx" --include="*.jsx" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+USE_EFFECT_FETCH=$(_cc_rg -n 'useEffect.*fetch\|useEffect.*axios\|useEffect.*api\.' "$SRC_DIR" --include="*.tsx" --include="*.jsx" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 add_check "No useEffect data fetching" "$( [ "$USE_EFFECT_FETCH" -eq 0 ] && echo 1 || echo 0 )" "${USE_EFFECT_FETCH} useEffect+fetch patterns"
 
 # --- Check 8: No direct DOM manipulation ---
-DIRECT_DOM=$(grep -rn 'document\.getElementById\|document\.querySelector\|document\.getElementsBy\|\.innerHTML\s*=' "$SRC_DIR" --include="*.tsx" --include="*.jsx" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | grep -v '\.test\.' | wc -l | tr -d ' ')
+DIRECT_DOM=$(_cc_rg -n 'document\.getElementById\|document\.querySelector\|document\.getElementsBy\|\.innerHTML\s*=' "$SRC_DIR" --include="*.tsx" --include="*.jsx" --include="*.ts" --include="*.js" 2>/dev/null | grep -v 'node_modules' | grep -v '\.test\.' | wc -l | tr -d ' ')
 add_check "No direct DOM manipulation" "$( [ "$DIRECT_DOM" -eq 0 ] && echo 1 || echo 0 )" "${DIRECT_DOM} document.* calls"
 
 # === CODE QUALITY CHECKS ===
 
 # --- Check 9: No var usage ---
-VAR_COUNT=$(grep -rn '\bvar\s' "$SRC_DIR" --include="*.ts" --include="*.js" --include="*.tsx" --include="*.jsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
+VAR_COUNT=$(_cc_rg -n '\bvar\s' "$SRC_DIR" --include="*.ts" --include="*.js" --include="*.tsx" --include="*.jsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
 add_check "No var usage" "$( [ "$VAR_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${VAR_COUNT} var declarations"
 
 # --- Check 10: No console.log in production ---
-CONSOLE_COUNT=$(grep -rn 'console\.\(log\|debug\|info\)' "$SRC_DIR" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.test\.' | grep -v '\.spec\.' | wc -l | tr -d ' ')
+CONSOLE_COUNT=$(_cc_rg -n 'console\.\(log\|debug\|info\)' "$SRC_DIR" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.test\.' | grep -v '\.spec\.' | wc -l | tr -d ' ')
 add_check "No console.log in prod" "$( [ "$CONSOLE_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${CONSOLE_COUNT} console statements"
 
 # --- Check 11: No barrel files (index.ts re-exports) ---
@@ -80,7 +85,7 @@ BARREL_COUNT=$(find "$SRC_DIR" \( -name "index.ts" -o -name "index.tsx" -o -name
 add_check "No barrel files" "$( [ "$BARREL_COUNT" -le 1 ] && echo 1 || echo 0 )" "${BARREL_COUNT} barrel index files"
 
 # --- Check 12: No inline styles ---
-INLINE_STYLE=$(grep -rn 'style={{' "$SRC_DIR" --include="*.tsx" --include="*.jsx" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+INLINE_STYLE=$(_cc_rg -n 'style={{' "$SRC_DIR" --include="*.tsx" --include="*.jsx" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 add_check "No inline styles" "$( [ "$INLINE_STYLE" -le 5 ] && echo 1 || echo 0 )" "${INLINE_STYLE} inline style objects"
 
 # === TOOLING CHECKS ===
@@ -119,11 +124,11 @@ CRA=${CRA:-0}
 add_check "No CRA (use Vite/Next)" "$( [ "$CRA" -eq 0 ] && echo 1 || echo 0 )" "$([ "$CRA" -gt 0 ] && echo 'react-scripts found in package.json')"
 
 # --- Check 17: No require() in TS/TSX ---
-REQUIRE_COUNT=$(grep -rn '\brequire(' "$SRC_DIR" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
+REQUIRE_COUNT=$(_cc_rg -n '\brequire(' "$SRC_DIR" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v 'node_modules' | grep -v '\.d\.ts' | wc -l | tr -d ' ')
 add_check "ES imports (no require)" "$( [ "$REQUIRE_COUNT" -eq 0 ] && echo 1 || echo 0 )" "${REQUIRE_COUNT} require() calls"
 
 # --- Check 18: No jQuery ---
-JQUERY=$(grep -rn '\$(\|\bjQuery\b' "$SRC_DIR" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
+JQUERY=$(_cc_rg -n '\$(\|\bjQuery\b' "$SRC_DIR" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" 2>/dev/null | grep -v 'node_modules' | wc -l | tr -d ' ')
 add_check "No jQuery" "$( [ "$JQUERY" -eq 0 ] && echo 1 || echo 0 )" "${JQUERY} jQuery usages"
 
 # Calculate score

--- a/language-packs/spring-boot/fitness-checks.sh
+++ b/language-packs/spring-boot/fitness-checks.sh
@@ -5,6 +5,11 @@
 # Note: set -e omitted intentionally — grep exits non-zero on no-match, which would abort the script
 set -u
 
+# Source shared utilities for _cc_rg (ripgrep with grep fallback)
+_CC_COMMON="$(cd "$(dirname "$0")/.." && pwd)/_common.sh"
+# shellcheck disable=SC1090
+[ -f "$_CC_COMMON" ] && source "$_CC_COMMON"
+
 PROJECT_DIR="${1:-.}"
 SRC_DIR="$PROJECT_DIR/src/main/java"
 [ ! -d "$SRC_DIR" ] && SRC_DIR="$PROJECT_DIR/src"
@@ -31,47 +36,47 @@ add_check() {
 # === TYPE SAFETY CHECKS ===
 
 # --- Check 1: No raw type usage (List, Map, Set without generics) ---
-RAW_TYPES=$(grep -rn '[[:space:]]List[[:space:]].*=[[:space:]]*new\|[[:space:]]Map[[:space:]].*=[[:space:]]*new\|[[:space:]]Set[[:space:]].*=[[:space:]]*new' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -v '/test/' | grep -vc 'node_modules' || true)
+RAW_TYPES=$(_cc_rg -n '[[:space:]]List[[:space:]].*=[[:space:]]*new\|[[:space:]]Map[[:space:]].*=[[:space:]]*new\|[[:space:]]Set[[:space:]].*=[[:space:]]*new' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -v '/test/' | grep -vc 'node_modules' || true)
 add_check "No raw types" "$( [ "$RAW_TYPES" -le 2 ] && echo 1 || echo 0 )" "${RAW_TYPES} raw type usages"
 
 # --- Check 2: No Object as parameter or return type (weak typing) ---
-OBJECT_TYPES=$(grep -rn 'Object>[[:space:]].*(' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -v '/test/' | grep -v '/generated/' | grep -vc '@Override' || true)
+OBJECT_TYPES=$(_cc_rg -n 'Object>[[:space:]].*(' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -v '/test/' | grep -v '/generated/' | grep -vc '@Override' || true)
 add_check "No Object return/param types" "$( [ "$OBJECT_TYPES" -le 3 ] && echo 1 || echo 0 )" "${OBJECT_TYPES} Object usages"
 
 # --- Check 3: No @SuppressWarnings("unchecked") ---
-SUPPRESS_UNCHECKED=$(grep -rn '@SuppressWarnings.*unchecked' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -vc '/test/' || true)
+SUPPRESS_UNCHECKED=$(_cc_rg -n '@SuppressWarnings.*unchecked' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -vc '/test/' || true)
 add_check "No @SuppressWarnings(unchecked)" "$( [ "$SUPPRESS_UNCHECKED" -eq 0 ] && echo 1 || echo 0 )" "${SUPPRESS_UNCHECKED} suppressions"
 
 # === SPRING PATTERN CHECKS ===
 
 # --- Check 4: Constructor injection over @Autowired field injection ---
-FIELD_AUTOWIRED=$(grep -rn '@Autowired' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -v '/test/' | grep -vc 'constructor' || true)
+FIELD_AUTOWIRED=$(_cc_rg -n '@Autowired' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -v '/test/' | grep -vc 'constructor' || true)
 add_check "Constructor injection (no field @Autowired)" "$( [ "$FIELD_AUTOWIRED" -le 2 ] && echo 1 || echo 0 )" "${FIELD_AUTOWIRED} field @Autowired"
 
 # --- Check 5: @ConfigurationProperties over @Value for structured config ---
-VALUE_COUNT=$(grep -rn '@Value(' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -vc '/test/' || true)
+VALUE_COUNT=$(_cc_rg -n '@Value(' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -vc '/test/' || true)
 add_check "@ConfigurationProperties over @Value" "$( [ "$VALUE_COUNT" -le 5 ] && echo 1 || echo 0 )" "${VALUE_COUNT} @Value usages"
 
 # --- Check 6: @Transactional on service layer, not controllers ---
-TXN_CONTROLLER=$(grep -rln '@Transactional' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -ciE 'Controller' || true)
+TXN_CONTROLLER=$(_cc_rg -l '@Transactional' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -ciE 'Controller' || true)
 add_check "@Transactional not on controllers" "$( [ "$TXN_CONTROLLER" -eq 0 ] && echo 1 || echo 0 )" "${TXN_CONTROLLER} controllers with @Transactional"
 
 # --- Check 7: No WebSecurityConfigurerAdapter (removed in Spring Security 6) ---
-LEGACY_SECURITY=$(grep -rn 'WebSecurityConfigurerAdapter' "$SRC_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
+LEGACY_SECURITY=$(_cc_rg -n 'WebSecurityConfigurerAdapter' "$SRC_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
 add_check "No WebSecurityConfigurerAdapter" "$( [ "$LEGACY_SECURITY" -eq 0 ] && echo 1 || echo 0 )" "${LEGACY_SECURITY} legacy security config"
 
 # === SECURITY CHECKS ===
 
 # --- Check 8: No hardcoded credentials ---
-HARDCODED_CREDS=$(grep -rn 'password[[:space:]]*=[[:space:]]*"[^"]*"\|secret[[:space:]]*=[[:space:]]*"[^"]*"\|api[_-]*key[[:space:]]*=[[:space:]]*"[^"]*"' "$SRC_DIR" --include="*.java" --include="*.properties" --include="*.yml" --include="*.yaml" 2>/dev/null | grep -vic 'test\|example\|placeholder\|changeme\|TODO' || true)
+HARDCODED_CREDS=$(_cc_rg -n 'password[[:space:]]*=[[:space:]]*"[^"]*"\|secret[[:space:]]*=[[:space:]]*"[^"]*"\|api[_-]*key[[:space:]]*=[[:space:]]*"[^"]*"' "$SRC_DIR" --include="*.java" --include="*.properties" --include="*.yml" --include="*.yaml" 2>/dev/null | grep -vic 'test\|example\|placeholder\|changeme\|TODO' || true)
 add_check "No hardcoded credentials" "$( [ "$HARDCODED_CREDS" -eq 0 ] && echo 1 || echo 0 )" "${HARDCODED_CREDS} hardcoded credentials"
 
 # --- Check 9: CSRF configuration present (not blindly disabled) ---
-CSRF_DISABLED=$(grep -rn 'csrf.*disable\|csrf().disable' "$SRC_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
+CSRF_DISABLED=$(_cc_rg -n 'csrf.*disable\|csrf().disable' "$SRC_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
 add_check "CSRF not blindly disabled" "$( [ "$CSRF_DISABLED" -eq 0 ] && echo 1 || echo 0 )" "${CSRF_DISABLED} csrf().disable() calls"
 
 # --- Check 10: Actuator endpoints not fully exposed ---
-ACTUATOR_EXPOSE_ALL=$(grep -rn 'management.endpoints.web.exposure.include[[:space:]]*=[[:space:]]*[*]' "$PROJECT_DIR" --include="*.properties" --include="*.yml" --include="*.yaml" 2>/dev/null | wc -l | tr -d ' ')
+ACTUATOR_EXPOSE_ALL=$(_cc_rg -n 'management.endpoints.web.exposure.include[[:space:]]*=[[:space:]]*[*]' "$PROJECT_DIR" --include="*.properties" --include="*.yml" --include="*.yaml" 2>/dev/null | wc -l | tr -d ' ')
 add_check "Actuator not fully exposed" "$( [ "$ACTUATOR_EXPOSE_ALL" -eq 0 ] && echo 1 || echo 0 )" "${ACTUATOR_EXPOSE_ALL} expose-all configs"
 
 # === TESTING CHECKS ===
@@ -93,8 +98,8 @@ fi
 add_check "Test coverage >40% files" "$( [ "$TEST_RATIO" -ge 40 ] && echo 1 || echo 0 )" "${TEST_COUNT} tests / ${SOURCE_COUNT} sources (${TEST_RATIO}%)"
 
 # --- Check 12: @SpringBootTest not overused (prefer test slices) ---
-FULL_BOOT_TEST=$(grep -rn '@SpringBootTest' "$TEST_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
-SLICE_TEST=$(grep -rn '@WebMvcTest\|@DataJpaTest\|@WebFluxTest\|@JsonTest\|@RestClientTest\|@JdbcTest' "$TEST_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
+FULL_BOOT_TEST=$(_cc_rg -n '@SpringBootTest' "$TEST_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
+SLICE_TEST=$(_cc_rg -n '@WebMvcTest\|@DataJpaTest\|@WebFluxTest\|@JsonTest\|@RestClientTest\|@JdbcTest' "$TEST_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
 TOTAL_TEST_CONFIGS=$((FULL_BOOT_TEST + SLICE_TEST))
 if [ "$TOTAL_TEST_CONFIGS" -gt 0 ]; then
     SLICE_PERCENT=$(( (SLICE_TEST * 100) / TOTAL_TEST_CONFIGS ))
@@ -104,7 +109,7 @@ fi
 add_check "Test slices over @SpringBootTest >40%" "$( [ "$SLICE_PERCENT" -ge 40 ] || [ "$TOTAL_TEST_CONFIGS" -le 2 ] && echo 1 || echo 0 )" "${SLICE_PERCENT}% slices (${SLICE_TEST} slice / ${FULL_BOOT_TEST} full)"
 
 # --- Check 13: Testcontainers usage (integration tests) ---
-TESTCONTAINERS=$(grep -rn 'Testcontainers\|@Container\|@ServiceConnection' "$TEST_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
+TESTCONTAINERS=$(_cc_rg -n 'Testcontainers\|@Container\|@ServiceConnection' "$TEST_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
 IT_FILES=$(find "$TEST_DIR" -type f -name "*IT.java" 2>/dev/null | wc -l | tr -d ' ')
 if [ "$IT_FILES" -gt 0 ]; then
     add_check "Testcontainers for integration tests" "$( [ "$TESTCONTAINERS" -gt 0 ] && echo 1 || echo 0 )" "${TESTCONTAINERS} Testcontainers refs, ${IT_FILES} IT files"
@@ -127,7 +132,7 @@ if [ -z "$BOOT_VERSION" ] && [ -f "$PROJECT_DIR/build.gradle.kts" ]; then
 fi
 BOOT_VERSION=${BOOT_VERSION:-0}
 
-JAVAX_IMPORTS=$(grep -rn 'import javax\.' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -v '/test/' | grep -vc 'javax.crypto\|javax.net\|javax.sql' || true)
+JAVAX_IMPORTS=$(_cc_rg -n 'import javax\.' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -v '/test/' | grep -vc 'javax.crypto\|javax.net\|javax.sql' || true)
 if [ "$BOOT_VERSION" -ge 3 ]; then
     add_check "jakarta imports (no javax for v3+)" "$( [ "$JAVAX_IMPORTS" -eq 0 ] && echo 1 || echo 0 )" "${JAVAX_IMPORTS} javax imports in v${BOOT_VERSION}"
 else
@@ -135,8 +140,8 @@ else
 fi
 
 # --- Check 15: RestTemplate vs RestClient (v3.2+ should use RestClient) ---
-REST_TEMPLATE=$(grep -rn 'RestTemplate' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -vc '/test/' || true)
-REST_CLIENT=$(grep -rn 'RestClient' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -vc '/test/' || true)
+REST_TEMPLATE=$(_cc_rg -n 'RestTemplate' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -vc '/test/' || true)
+REST_CLIENT=$(_cc_rg -n 'RestClient' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -vc '/test/' || true)
 if [ "$BOOT_VERSION" -ge 3 ]; then
     add_check "RestClient over RestTemplate (v3.2+)" "$( [ "$REST_TEMPLATE" -le 2 ] || [ "$REST_CLIENT" -gt 0 ] && echo 1 || echo 0 )" "${REST_TEMPLATE} RestTemplate, ${REST_CLIENT} RestClient"
 else
@@ -145,7 +150,7 @@ fi
 
 # --- Check 16: Virtual threads configuration (v3.2+ / Java 21+) ---
 if [ "$BOOT_VERSION" -ge 3 ]; then
-    VIRTUAL_THREADS=$(grep -rn 'virtual-threads\|virtual.threads' "$PROJECT_DIR" --include="*.properties" --include="*.yml" --include="*.yaml" 2>/dev/null | wc -l | tr -d ' ')
+    VIRTUAL_THREADS=$(_cc_rg -n 'virtual-threads\|virtual.threads' "$PROJECT_DIR" --include="*.properties" --include="*.yml" --include="*.yaml" 2>/dev/null | wc -l | tr -d ' ')
     add_check "Virtual threads considered (v3.2+)" "$( [ "$VIRTUAL_THREADS" -gt 0 ] && echo 1 || echo 0 )" "${VIRTUAL_THREADS} virtual thread configs"
 else
     add_check "Virtual threads (v2.x not applicable)" 1 "v${BOOT_VERSION} (virtual threads N/A)"
@@ -154,12 +159,12 @@ fi
 # === CODE QUALITY CHECKS ===
 
 # --- Check 17: No System.out.println in production code ---
-SYSOUT=$(grep -rn 'System\.out\.print\|System\.err\.print' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -vc '/test/' || true)
+SYSOUT=$(_cc_rg -n 'System\.out\.print\|System\.err\.print' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -vc '/test/' || true)
 add_check "No System.out.println" "$( [ "$SYSOUT" -eq 0 ] && echo 1 || echo 0 )" "${SYSOUT} System.out/err usages"
 
 # --- Check 18: Proper exception handling (@RestControllerAdvice) ---
-CONTROLLER_ADVICE=$(grep -rn '@RestControllerAdvice\|@ControllerAdvice' "$SRC_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
-CONTROLLERS=$(grep -rn '@RestController\|@Controller' "$SRC_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
+CONTROLLER_ADVICE=$(_cc_rg -n '@RestControllerAdvice\|@ControllerAdvice' "$SRC_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
+CONTROLLERS=$(_cc_rg -n '@RestController\|@Controller' "$SRC_DIR" --include="*.java" 2>/dev/null | wc -l | tr -d ' ')
 if [ "$CONTROLLERS" -gt 0 ]; then
     add_check "Global exception handling exists" "$( [ "$CONTROLLER_ADVICE" -gt 0 ] && echo 1 || echo 0 )" "${CONTROLLER_ADVICE} @ControllerAdvice (${CONTROLLERS} controllers)"
 else

--- a/language-packs/struts-jsp/fitness-checks.sh
+++ b/language-packs/struts-jsp/fitness-checks.sh
@@ -4,6 +4,11 @@
 # Focus: code quality, security, migration readiness assessment
 set -u
 
+# Source shared utilities for _cc_rg (ripgrep with grep fallback)
+_CC_COMMON="$(cd "$(dirname "$0")/.." && pwd)/_common.sh"
+# shellcheck disable=SC1090
+[ -f "$_CC_COMMON" ] && source "$_CC_COMMON"
+
 PROJECT_DIR="${1:-.}"
 TOTAL_CHECKS=0
 PASSED_CHECKS=0
@@ -41,15 +46,15 @@ done
 
 # Check for raw types (Map, List without generics)
 if [ -n "$SRC_DIR" ] && [ -d "$SRC_DIR" ]; then
-    raw_types=$(grep -rn 'Map[[:space:]]*[a-z]' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -v 'Map<' | grep -cv '^\s*//' || echo "0")
+    raw_types=$(_cc_rg -n 'Map[[:space:]]*[a-z]' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -v 'Map<' | grep -cv '^\s*//' || echo "0")
     add_check "No raw Map types" "$([ "$raw_types" -lt 5 ] && echo 1 || echo 0)" "${raw_types} raw Map usages"
 
     # Check for Object parameters
-    obj_params=$(grep -rn 'Object[[:space:]]\+[a-z]' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -cv '^\s*//' || echo "0")
+    obj_params=$(_cc_rg -n 'Object[[:space:]]\+[a-z]' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -cv '^\s*//' || echo "0")
     add_check "Minimal Object params" "$([ "$obj_params" -lt 10 ] && echo 1 || echo 0)" "${obj_params} Object params"
 
     # Check for @SuppressWarnings abuse
-    suppress_count=$(grep -rc '@SuppressWarnings' "$SRC_DIR" --include="*.java" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
+    suppress_count=$(_cc_rg -c '@SuppressWarnings' "$SRC_DIR" --include="*.java" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
     add_check "Minimal @SuppressWarnings" "$([ "$suppress_count" -lt 20 ] && echo 1 || echo 0)" "${suppress_count} suppressions"
 fi
 
@@ -57,19 +62,19 @@ fi
 
 if [ -n "$WEB_DIR" ] && [ -d "$WEB_DIR" ]; then
     # Count scriptlet usage
-    scriptlet_count=$(grep -rc '<%[^@=-]' "$WEB_DIR" --include="*.jsp" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
+    scriptlet_count=$(_cc_rg -c '<%[^@=-]' "$WEB_DIR" --include="*.jsp" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
     add_check "JSP scriptlet audit" "$([ "$scriptlet_count" -lt 50 ] && echo 1 || echo 0)" "${scriptlet_count} scriptlets"
 
     # Check for JSTL usage (good sign)
-    jstl_count=$(grep -rc 'taglib.*jstl\|<c:\|<fmt:' "$WEB_DIR" --include="*.jsp" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
+    jstl_count=$(_cc_rg -c 'taglib.*jstl\|<c:\|<fmt:' "$WEB_DIR" --include="*.jsp" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
     add_check "JSTL adoption" "$([ "$jstl_count" -gt 0 ] && echo 1 || echo 0)" "${jstl_count} JSTL usages"
 
     # Check for inline JavaScript in JSPs
-    inline_js=$(grep -rc '<script[^>]*>' "$WEB_DIR" --include="*.jsp" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
+    inline_js=$(_cc_rg -c '<script[^>]*>' "$WEB_DIR" --include="*.jsp" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
     add_check "Minimal inline JS in JSP" "$([ "$inline_js" -lt 20 ] && echo 1 || echo 0)" "${inline_js} inline scripts"
 
     # Check for inline SQL in JSPs (very bad)
-    inline_sql=$(grep -rci 'SELECT.*FROM\|INSERT.*INTO\|UPDATE.*SET\|DELETE.*FROM' "$WEB_DIR" --include="*.jsp" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
+    inline_sql=$(_cc_rg -ci 'SELECT.*FROM\|INSERT.*INTO\|UPDATE.*SET\|DELETE.*FROM' "$WEB_DIR" --include="*.jsp" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
     add_check "No SQL in JSPs" "$([ "$inline_sql" -eq 0 ] && echo 1 || echo 0)" "${inline_sql} SQL statements in JSPs"
 fi
 
@@ -113,19 +118,19 @@ fi
 
 if [ -n "$SRC_DIR" ] && [ -d "$SRC_DIR" ]; then
     # Check for SQL injection patterns (string concat in queries)
-    sql_concat=$(grep -rn 'createQuery\|createSQLQuery\|prepareStatement\|executeQuery' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -c '+' || echo "0")
+    sql_concat=$(_cc_rg -n 'createQuery\|createSQLQuery\|prepareStatement\|executeQuery' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -c '+' || echo "0")
     add_check "No SQL string concatenation" "$([ "$sql_concat" -eq 0 ] && echo 1 || echo 0)" "${sql_concat} potential SQL injections"
 
     # Check for hardcoded credentials
-    hardcoded_creds=$(grep -rni 'password\s*=\s*"[^"]\+"\|passwd\s*=\s*"' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -cv '^\s*//' || echo "0")
+    hardcoded_creds=$(_cc_rg -ni 'password\s*=\s*"[^"]\+"\|passwd\s*=\s*"' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -cv '^\s*//' || echo "0")
     add_check "No hardcoded credentials" "$([ "$hardcoded_creds" -eq 0 ] && echo 1 || echo 0)" "${hardcoded_creds} hardcoded credentials"
 
     # Check for System.out (should use logging)
-    sysout=$(grep -rc 'System\.out\.\|System\.err\.' "$SRC_DIR" --include="*.java" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
+    sysout=$(_cc_rg -c 'System\.out\.\|System\.err\.' "$SRC_DIR" --include="*.java" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
     add_check "No System.out (use logger)" "$([ "$sysout" -lt 10 ] && echo 1 || echo 0)" "${sysout} System.out calls"
 
     # Check for exception swallowing
-    empty_catch=$(grep -rn 'catch.*{' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -c '{}' || echo "0")
+    empty_catch=$(_cc_rg -n 'catch.*{' "$SRC_DIR" --include="*.java" 2>/dev/null | grep -c '{}' || echo "0")
     add_check "No empty catch blocks" "$([ "$empty_catch" -eq 0 ] && echo 1 || echo 0)" "${empty_catch} empty catches"
 fi
 
@@ -144,7 +149,7 @@ if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
     add_check "Has test files" "$([ "$test_count" -gt 0 ] && echo 1 || echo 0)" "${test_count} test files"
 
     # Check for assertions (not just test methods)
-    assertions=$(grep -rc 'assert\|assertEquals\|assertTrue\|assertThat\|verify(' "$TEST_DIR" --include="*.java" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
+    assertions=$(_cc_rg -c 'assert\|assertEquals\|assertTrue\|assertThat\|verify(' "$TEST_DIR" --include="*.java" 2>/dev/null | awk -F: '{sum+=$2} END{print sum+0}')
     add_check "Tests have assertions" "$([ "$assertions" -gt 5 ] && echo 1 || echo 0)" "${assertions} assertions"
 else
     add_check "Test directory exists" 0 "no test directory found"


### PR DESCRIPTION
## Summary

- Add `_cc_rg()` composable utility for recursive file search (ripgrep with grep fallback)
- Migrate 87 recursive grep calls across 7 language pack fitness-checks.sh files
- Add `language-packs/_common.sh` shared utility library

## Changes

| File | Change |
|------|--------|
| `language-packs/_common.sh` | **NEW** — shared `_cc_rg()` function with rg detection, flag translation, BRE→ERE regex dialect conversion, `--all` flag for gitignored files |
| `language-packs/angular/fitness-checks.sh` | 18 `grep -rn` → `_cc_rg -n` |
| `language-packs/node/fitness-checks.sh` | 7 calls migrated |
| `language-packs/perl/fitness-checks.sh` | 4 calls migrated |
| `language-packs/python/fitness-checks.sh` | 11 calls migrated |
| `language-packs/react/fitness-checks.sh` | 13 calls migrated |
| `language-packs/spring-boot/fitness-checks.sh` | 21 calls migrated |
| `language-packs/struts-jsp/fitness-checks.sh` | 13 calls migrated |

## Key design decisions

- **Compose, not inline** — wrapper is a shared utility, not inlined into every hook
- **Hooks untouched** — all 78 hook grep calls are stdin pipe/single-file (zero rg benefit)
- **No auto-install** — framework convention: detect and fallback, never install tools
- **BRE regex translation** — converts `\|`, `\(`, `\)` to ERE for rg compatibility
- **`--all` flag** — `rg --no-ignore` for agents that need to scan gitignored files
- **`| grep -v node_modules` preserved** — needed for grep fallback path equivalence

## Test plan

- [x] Angular fitness-check on real project: rg path = 94% (17/18)
- [x] Same test with grep fallback (rg absent): 94% (17/18) — identical
- [x] All 7 fitness-checks pass `bash -n` syntax validation
- [x] `--all` flag works (searches gitignored files)

## Evidence

- [Peer-reviewed benchmark paper (v3.0)](https://github.com/wolaschka/dev-notes/blob/main/docs/research/2026-03-24-ripgrep-vs-grep-benchmark.md)
- [Workspace benchmark results](https://github.com/mindcockpit-ai/cognitive-core/issues/134#issuecomment-4118400482)
- [Scope revision with data](https://github.com/mindcockpit-ai/cognitive-core/issues/134#issuecomment-4119174676)

Closes #134 (Phase 1)