### PR TITLE
fix(ci): configure squash merges to prevent changelog duplicates

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,11 @@
       "release-type": "simple",
       "bump-minor-pre-major": true,
       "include-v-in-tag": true,
+      "exclude-commits-from-changelog": [
+        "merge conflict",
+        "Merge pull request",
+        "Merge branch"
+      ],
       "changelog-sections": [
         { "type": "feat", "section": "Features", "hidden": false },
         { "type": "fix", "section": "Bug Fixes", "hidden": false },


### PR DESCRIPTION
## Summary
- Configure GitHub repo for squash merges only (`allow_merge_commit=false`, `allow_rebase_merge=false`)
- Set squash commit title to `PR_TITLE` and message to `PR_BODY` for clean conventional commits
- Add `exclude-commits-from-changelog` patterns to `release-please-config.json` as safety net

## Root Cause
PR #143 (v1.3.0) contained 4 duplicate changelog entries and 1 noise entry because merge commits duplicated feature commits — Release Please picked up both.

## Verification
- `gh api repos/mindcockpit-ai/cognitive-core --jq '{squash: .allow_squash_merge, merge: .allow_merge_commit, rebase: .allow_rebase_merge}'` returns `{squash: true, merge: false, rebase: false}`
- `python3 -c "import json; json.load(open('release-please-config.json'))"` exits 0

Closes #156