### PR TITLE
fix(jira): migrate to /rest/api/3/search/jql endpoint

### DIFF
--- a/core/skills/project-board/providers/jira.sh
+++ b/core/skills/project-board/providers/jira.sh
@@ -297,7 +297,7 @@ pb_issue_list() {
     fi
     jql+=" ORDER BY priority ASC, created DESC"
 
-    _jira_api GET "/search?jql=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$jql'))")&fields=summary,status,priority,assignee,labels&maxResults=50"
+    _jira_api GET "/search/jql?jql=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$jql'))")&fields=summary,status,priority,assignee,labels&maxResults=50"
 }
 
 pb_issue_create() {
@@ -440,7 +440,7 @@ pb_issue_assign() {
 pb_board_summary() {
     local jql="project = ${CC_JIRA_PROJECT} AND statusCategory != Done"
     local result
-    result=$(_jira_api GET "/search?jql=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$jql'))")&fields=status&maxResults=200")
+    result=$(_jira_api GET "/search/jql?jql=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$jql'))")&fields=status&maxResults=200")
 
     echo "$result" | python3 -c "
 import json, sys


### PR DESCRIPTION
## Summary
- Replace `/rest/api/3/search?jql=` with `/rest/api/3/search/jql?jql=` in `pb_issue_list` (line 300) and `pb_board_summary` (line 443)
- Jira Cloud removed the old endpoint (HTTP 410, ref: Atlassian CHANGE-2046)

## Impact
- `board summary` and `issue list` commands were completely broken on Jira Cloud instances
- Discovered 2026-03-25 on netsavehtml project (CAI board)

## Verification
- `grep -c '/search?jql=' jira.sh` = 0 (old endpoint eliminated)
- `grep -c '/search/jql' jira.sh` = 2 (both call sites migrated)
- `bash -n jira.sh` = OK
- ShellCheck = PASS (suite 01)
- 17/18 test suites pass (suite 17 pre-existing, unrelated)

Closes #150