### PR TITLE
fix(install): add security + AI tooling patterns to gitignore template

### DIFF
--- a/core/templates/gitignore-base
+++ b/core/templates/gitignore-base
@@ -34,6 +34,10 @@ $RECYCLE.BIN/
 *~
 .directory
 .Trash-*
+.fuse_hidden*
+.nfs*
+nohup.out
+*.stackdump
 
 # ---- Build output (common) ----
 build/
@@ -160,6 +164,15 @@ nppBackup/
 # Cursor
 .cursor/
 
+# AI / LLM tool runtime (2025+)
+.aider*
+.windsurf/
+.cline/
+.continue/
+.codex/
+.amazonq/
+.tabnine_root
+
 # ---- Secrets and credentials ----
 .env
 .env.*
@@ -180,16 +193,36 @@ service-account*.json
 .secret
 .secrets
 .htpasswd
+.envrc
+.npmrc
+.docker/config.json
 
 # IaC and cloud credentials
 terraform.tfstate
 terraform.tfstate.backup
+*.tfvars
+*.tfvars.json
 .terraform/
+.terraformrc
+terraform.rc
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
 # .terraform.lock.hcl — commit this (reproducible provider versions)
+.pulumi/
+cdk.out/
+.cdk.staging/
+cdk.context.json
 .aws/credentials
 .kube/config
 .netrc
 vault-token
+
+# JetBrains HTTP Client secrets (outside .idea/)
+http-client.private.env.json
 
 # ---- Logs ----
 *.log


### PR DESCRIPTION
## Summary

Based on T1 research (GitHub official gitignore templates, tool repos), adds 33 missing patterns:

### Security (HIGH risk if committed)
- `*.tfvars` / `*.tfvars.json` — Terraform secrets
- `http-client.private.env.json` — JetBrains HTTP Client API keys
- `.envrc` — direnv secrets (not caught by `.env.*`)
- `.npmrc` — npm auth tokens
- `.docker/config.json` — Docker registry credentials
- Terraform crash logs, overrides, `.terraformrc`
- Pulumi, AWS CDK state directories

### AI/LLM Tooling (cognitive-core only covered `.cursor/`)
- `.aider*`, `.windsurf/`, `.cline/`, `.continue/`, `.codex/`, `.amazonq/`, `.tabnine_root`

### OS
- `.fuse_hidden*`, `.nfs*`, `nohup.out`, `*.stackdump`

## Test plan
- [x] Suite 15 (gitignore policy): 138/138 passed