### PR TITLE
fix(rules): add Angular 21 conventions rule with security enforcement (#213)

### DIFF
--- a/core/hooks/angular-version-guard.sh
+++ b/core/hooks/angular-version-guard.sh
@@ -146,6 +146,31 @@ if [ "$NG_VERSION" -ge 21 ] && [ -z "$REASON" ]; then
     fi
 fi
 
+# --- Security patterns (all versions) ---
+if [ -z "$REASON" ]; then
+    # bypassSecurityTrust (DomSanitizer bypass)
+    if echo "$CONTENT" | grep -qE 'bypassSecurityTrust(Html|Url|Script|Style|ResourceUrl)'; then
+        REASON="Angular security: bypassSecurityTrust detected. Use a dedicated sanitization pipe with tests and a SECURITY comment referencing the issue tracker."
+    fi
+
+    # innerHTML with interpolation (potential XSS)
+    if [ -z "$REASON" ] && echo "$CONTENT" | grep -qE '\[innerHTML\]'; then
+        REASON="Angular security: [innerHTML] binding detected. Ensure the value is not user-controlled. Prefer Angular template syntax."
+    fi
+
+    # eval / document.write / new Function
+    if [ -z "$REASON" ] && echo "$CONTENT" | grep -qE '(^|[[:space:];])eval[[:space:]]*\(|document\.write[[:space:]]*\(|new[[:space:]]+Function[[:space:]]*\('; then
+        REASON="Angular security: eval()/document.write()/new Function() detected. These enable XSS — use Angular APIs instead."
+    fi
+
+    # Secrets in environment.ts
+    if [ -z "$REASON" ] && echo "$FILE_PATH" | grep -qE 'environment[^/]*\.ts$'; then
+        if echo "$CONTENT" | grep -qiE '(api[_-]?key|secret|password|token)[[:space:]]*[:=]'; then
+            REASON="Angular security: potential secret in environment file. Use InjectionToken + runtime config — environment.ts is compiled into the bundle."
+        fi
+    fi
+fi
+
 # Output ask JSON if pattern found, otherwise silent exit 0
 if [ -n "$REASON" ]; then
     _cc_security_log "ASK" "angular-version-guard" "${REASON} | file=${FILE_PATH}"

--- a/language-packs/angular/rules/angular-conventions.md
+++ b/language-packs/angular/rules/angular-conventions.md
@@ -2,9 +2,66 @@
 paths: ["**/*.ts", "**/*.html", "**/*.scss"]
 ---
 
-# Angular Conventions
+# Angular Conventions (v21+)
 
-- Use signals for reactive state (Angular 18+)
-- Standalone components over NgModule declarations
-- Inject services via `inject()` function or constructor
-- Use reactive forms over template-driven forms
+## Architecture
+- Standalone components only — no NgModules for features
+- `inject()` function for all DI — no constructor injection in components/services
+- Feature-based folder structure (`features/<name>/`)
+- Functional interceptors (`HttpInterceptorFn`) — no class-based `HttpInterceptor`
+- Functional guards and resolvers — no class-based
+- Lazy loading with `loadComponent` / `loadChildren` in routes
+- Bootstrap with `provideZonelessChangeDetection()` in `app.config.ts` — no zone.js (new projects; existing zone-based apps: migrate incrementally)
+
+## Reactivity
+- Signals for all local/shared state — `signal()`, `computed()`, `effect()`
+- `linkedSignal()` for writable signals derived from other signals — do NOT use `effect()` for signal-to-signal sync
+- RxJS only for streams (HTTP, WebSocket, complex async)
+- No `BehaviorSubject` for simple state — use `signal()` instead
+- Every `subscribe()` must have cleanup (`takeUntilDestroyed()` or `DestroyRef`)
+
+## Components
+- `ChangeDetectionStrategy.OnPush` on ALL components
+- Use `input()` / `input.required()` — not `@Input` decorator
+- Use `output()` — not `@Output` decorator
+- Use `model()` for two-way binding — not paired `@Input` + `@Output(nameChange)`
+- Use `viewChild()` / `viewChild.required()` / `viewChildren()` — not `@ViewChild` / `@ViewChildren`
+- Use `contentChild()` / `contentChildren()` — not `@ContentChild` / `@ContentChildren`
+- `@defer` blocks for below-fold content
+- `host: {}` in decorator — no `@HostBinding` / `@HostListener`
+- Template: `@if`, `@for`, `@switch` — no `*ngIf`, `*ngFor`, `*ngSwitch`
+- `@for` must have `track` expression
+- Template-only members: use `protected` — not `private`, not `public`
+
+## HTTP & API
+- `provideHttpClient(withInterceptors([...]))` in `app.config.ts`
+- Enable `withXsrf()` for cookie-based auth — omit only for stateless Bearer-token APIs
+- Relative API URLs (`/api/...`) — no hardcoded hostnames
+- `httpResource()` is in developer preview — do NOT use in production until Angular removes the preview label; use `HttpClient` + signals
+- `provideHttpClientTesting()` in tests — not `HttpClientTestingModule`
+- Every `HttpTestingController` test calls `httpMock.verify()` in afterEach
+
+## Security
+- No `bypassSecurityTrustHtml/Url/Script` — if required, use a dedicated sanitization pipe with tests and a `// SECURITY:` comment referencing the issue tracker
+- No `innerHTML` binding with user-controlled data
+- No `document.write()`, `eval()`, `new Function()`
+- No secrets in `environment.ts` — use `InjectionToken` + runtime config
+
+## IoC / DI
+- `InjectionToken` for swappable services
+- Implementations registered in `app.config.ts` via `{ provide: TOKEN, useClass: Impl }`
+
+## Testing
+- Test runner: Vitest via `@angular/build:unit-test` — not Karma, not Jest
+- `provideZonelessChangeDetection()` in TestBed setup
+- `provideHttpClientTesting()` for HTTP service tests
+- Signal inputs in tests: use `fixture.componentRef.setInput()` — not direct property assignment
+- One `fixture.detectChanges()` after signal updates — no loops
+- `httpMock.verify()` in afterEach for every HTTP test
+
+## Code Quality
+- TypeScript `strict: true` + `strictTemplates: true` + `strictInjectionParameters: true`
+- No `any` type — use `unknown` for uncertain types
+- `===` / `!==` in templates (never `==` / `!=`)
+- No `console.log` in production code
+- Kebab-case file names (`user-profile.component.ts`)


### PR DESCRIPTION
## Summary

- Replace 10-line Angular conventions placeholder with comprehensive 67-line rule (v21+)
- Add 4 security pattern checks to `angular-version-guard.sh`: `bypassSecurityTrust`, `[innerHTML]`, `eval`/`document.write`, environment secrets
- Rules audited against angular.dev (T1, 16 sources) for Angular 21.2.x
- Security review findings addressed: self-approving gate tightened, XSRF made explicit, httpResource dev-preview qualified

Closes #213

## Test plan
- [ ] `bash tests/run-all.sh` passes (19/19 suites)
- [ ] ShellCheck clean on `angular-version-guard.sh`
- [ ] Install.sh copies rule for `CC_LANGUAGE=angular` projects
- [ ] Version-guard hook catches `bypassSecurityTrust`, `[innerHTML]`, `eval()`, environment secrets