### PR TITLE
feat(skills): netsavehtml patterns — SSRF, iframe srcdoc, Security 7

### DIFF
--- a/core/skills/security-baseline/references/ssrf-config-registry.md
+++ b/core/skills/security-baseline/references/ssrf-config-registry.md
@@ -1,0 +1,109 @@
+# SSRF Elimination: Config Registry Proxy Pattern
+
+## Problem
+
+Server-side proxies that accept user-controlled URLs are inherently SSRF-prone.
+Even with allowlists, SonarCloud's S5144 (SSRF) rule correctly flags any path
+where user input reaches an HTTP client.
+
+Common vulnerable pattern:
+
+```java
+// VULNERABLE: user controls the URL, allowlist can be bypassed
+@GetMapping("/proxy")
+public ResponseEntity<String> proxy(@RequestParam String url) {
+    if (!ALLOWED_HOSTS.contains(URI.create(url).getHost())) {
+        return ResponseEntity.badRequest().build();
+    }
+    return restClient.get().uri(url).retrieve().toEntity(String.class);
+}
+```
+
+Allowlist bypasses include:
+- DNS rebinding (`formular.internal.evil.com` resolves to `169.254.169.254`)
+- Open redirects on allowed hosts
+- URL parser differentials (`http://allowed.com@evil.com`)
+
+## Solution: Config Registry Proxy
+
+Replace user-controlled URLs with server-side key-to-URL lookup:
+
+```java
+// SAFE: user provides a type key, URL resolved entirely from config
+@GetMapping("/proxy/form")
+public ResponseEntity<String> proxyForm(@RequestParam String type) {
+    // Validate key format (alphanumeric only, max 20 chars)
+    if (!FORM_TYPE_PATTERN.matcher(type).matches()) {
+        return ResponseEntity.badRequest().body(problemDetail("invalid type format"));
+    }
+
+    // Lookup URL from application.yml config — no user input in URL
+    String url = properties.getFormUrls().get(type);
+    if (null == url) {
+        return ResponseEntity.notFound().build();
+    }
+
+    // RestClient fetches from config-defined URL only
+    return restClient.get()
+        .uri(URI.create(url))
+        .retrieve()
+        .toEntity(String.class);
+}
+```
+
+Configuration:
+
+```yaml
+netsave:
+  form-urls:
+    meldeantrag: "https://formular.amt.de/meldeantrag.html"
+    anmeldung: "https://formular.amt.de/anmeldung.html"
+```
+
+## Why This Works
+
+- **No taint path**: user input (`type`) never reaches the HTTP client URI
+- **SonarCloud S5144 eliminated structurally**: taint analysis confirms no flow from request parameter to `RestClient.uri()`
+- **Key validation**: regex `^\w{1,20}$` prevents injection into the lookup itself
+- **Redirect following disabled**: prevents 302-based SSRF even if config URL is misconfigured
+
+## Additional Hardening
+
+```java
+// Disable redirects — prevents 302 to internal IPs
+SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory() {
+    @Override
+    protected void prepareConnection(HttpURLConnection connection, String httpMethod) throws IOException {
+        super.prepareConnection(connection, httpMethod);
+        connection.setInstanceFollowRedirects(false);
+    }
+};
+factory.setConnectTimeout(Duration.ofSeconds(5));
+factory.setReadTimeout(Duration.ofSeconds(10));
+
+RestClient restClient = RestClient.builder(factory).build();
+```
+
+## When to Use
+
+- Any server-side proxy that fetches external resources on behalf of the client
+- Form server proxies (CORS bypass for cross-origin form HTML)
+- PDF/document generation from external templates
+- Webhook forwarding where the destination is known at deploy time
+
+## When NOT to Use
+
+- User-initiated arbitrary URL fetching (e.g., link previews) — use a dedicated service with network-level isolation instead
+- APIs where the URL space is unbounded — consider an allowlist with DNS pinning
+
+## Verification
+
+After applying, run SonarCloud analysis and confirm:
+- S5144 (SSRF) no longer flagged
+- Security hotspot count drops (hotspot review should show "Safe")
+
+## Origin
+
+Discovered during NetSaveHTML CAI-31 (April 2026). Original proxy accepted
+`?url={user-controlled}` with host allowlist — SonarCloud correctly flagged S5144.
+Refactored to `?type=meldeantrag` → config map lookup. Zero security findings after change.

--- a/language-packs/angular/skills/angular-patterns/SKILL.md
+++ b/language-packs/angular/skills/angular-patterns/SKILL.md
@@ -51,6 +51,40 @@ When analyzing an Angular codebase, scan for these anti-patterns and quantify ea
 | Template injection | `[innerHTML]="userInput"` | Angular auto-sanitizes, but avoid where possible |
 | CSRF unprotected | Missing `HttpXsrfInterceptor` | `provideHttpClient(withXsrfConfiguration(...))` |
 
+#### Safe iframe srcdoc Pattern (bypassing Angular sanitizer)
+
+Angular's sanitizer strips `srcdoc` from `<iframe>` elements. When the HTML source
+is trusted (e.g., fetched from your own allowlisted proxy and processed client-side
+via DOMParser), use `afterNextRender()` to set `srcdoc` directly on the DOM:
+
+```typescript
+// Signal holds the view state; pendingHtml is set before switching to 'display'
+private pendingHtml = '';
+
+// In the subscribe/effect that prepares the HTML:
+this.pendingHtml = mergedHtml;
+this.viewState.set('display');
+this.cdr.markForCheck();
+
+// Set srcdoc AFTER Angular renders the iframe element
+afterNextRender(() => {
+  const iframe = document.querySelector('iframe.my-iframe') as HTMLIFrameElement;
+  if (null != iframe) {
+    iframe.srcdoc = this.pendingHtml;
+  }
+  this.pendingHtml = ''; // Clear reference to allow GC
+}, { injector: this.injector });
+```
+
+**When to use**: trusted HTML that Angular's sanitizer incorrectly strips (iframe srcdoc,
+SVG with scripts, etc.) where the source is under your control.
+
+**Requirements**:
+- HTML must come from a trusted, controlled source (your proxy, not user input)
+- Document the bypass justification in a code comment
+- Use `sandbox` attribute on the iframe for defense in depth
+- Clear `pendingHtml` after setting `srcdoc` to prevent memory leaks
+
 ## Version-Specific Patterns
 
 ### Angular 18 Patterns (June 2024)

--- a/language-packs/spring-boot/skills/spring-boot-patterns/SKILL.md
+++ b/language-packs/spring-boot/skills/spring-boot-patterns/SKILL.md
@@ -340,6 +340,44 @@ public class OrderAggregationService {
 ```
 
 ```java
+// Spring Security 7 (v4.0) — SecurityFilterChain for SPA (Angular/React)
+// Note: @Bean no longer needs `throws Exception` — Security 7 removed it
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) {
+        return http
+            .csrf(csrf -> csrf
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/v1/**").permitAll()
+                .anyRequest().authenticated())
+            .build();
+    }
+}
+
+// SPA CSRF helper — reads token from cookie, sends in X-XSRF-TOKEN header
+// Required for Angular/React frontends that send CSRF via header, not form field
+final class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler {
+    private final CsrfTokenRequestHandler delegate = new XorCsrfTokenRequestAttributeHandler();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       Supplier<CsrfToken> csrfToken) {
+        delegate.handle(request, response, csrfToken);
+    }
+
+    @Override
+    public String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken) {
+        return (request.getHeader(csrfToken.getHeaderName()) != null)
+            ? super.resolveCsrfTokenValue(request, csrfToken)
+            : delegate.resolveCsrfTokenValue(request, csrfToken);
+    }
+}
+
 // Spring Security 7 (v4.0) — method-level authorization
 @Service
 @PreAuthorize("hasRole('USER')")


### PR DESCRIPTION
## Summary
- **security-baseline**: SSRF elimination via config registry proxy pattern — replaces user-controlled URL proxy with key-to-URL lookup from server config
- **angular-patterns**: safe iframe `srcdoc` bypass using `afterNextRender()` — for trusted HTML that Angular's sanitizer incorrectly strips
- **spring-boot-patterns**: SecurityFilterChain SPA pattern for Spring Security 7 — CSRF cookie + SPA token handler, no `throws Exception` on `@Bean` methods

## Origin
Patterns extracted from [NetSaveHTML](https://bitbucket.org/bolsystemhaus/netsavehtml) CAI-8/CAI-31 implementation (April 2026). Battle-tested with 209 tests and SonarCloud clean analysis.

## Test plan
- [ ] Verify SSRF reference document renders correctly and is discoverable by security-baseline skill
- [ ] Verify angular-patterns iframe srcdoc section integrates with existing security anti-patterns table
- [ ] Verify spring-boot-patterns SPA SecurityFilterChain fits before existing method-level auth section