### PR TITLE
feat(packs): add NestJS/ORM/hexagonal/error-handling rules to node pack (#240)

### DIFF
--- a/language-packs/node/rules/error-handling.md
+++ b/language-packs/node/rules/error-handling.md
@@ -33,7 +33,7 @@ InfrastructureError (abstract base)
 ## Async Error Handling
 
 - Always `await` promises — never leave a promise floating without error handling
-- Use `try/catch` around `await` calls only when you can handle or enrich the error meaningfully
+- Use `try/catch` around `await` calls only to add context (wrap with a domain error) or to recover — do NOT catch-and-rethrow the same error
 - Let unhandled errors propagate to the global exception filter — do NOT catch-and-rethrow without adding context
 - Register a global `process.on('unhandledRejection')` handler that logs and exits with code 1
 

--- a/language-packs/node/rules/error-handling.md
+++ b/language-packs/node/rules/error-handling.md
@@ -1,0 +1,54 @@
+---
+paths: ["**/*.ts", "**/*.js"]
+---
+
+# Error Handling
+
+## Custom Error Classes
+
+- Define a base `DomainError` extending `Error` with a `code` property for programmatic identification
+- Create specific error subclasses per domain concept: `UserNotFoundError`, `InsufficientBalanceError`
+- Set `this.name = this.constructor.name` in the constructor for meaningful stack traces
+- Never throw plain strings or generic `Error('something failed')` — always use typed errors
+
+## Error Hierarchy
+
+```
+DomainError (abstract base)
+  ├── NotFoundError          → 404
+  ├── ValidationError        → 400
+  ├── ConflictError          → 409
+  ├── UnauthorizedError      → 401
+  └── ForbiddenError         → 403
+InfrastructureError (abstract base)
+  ├── DatabaseError          → 500
+  ├── ExternalServiceError   → 502
+  └── TimeoutError           → 504
+```
+
+- Domain errors represent business rule violations — they carry no HTTP semantics
+- Infrastructure errors wrap external failures — database, network, third-party APIs
+- Map error types to HTTP status codes in the exception filter, not at the throw site
+
+## Async Error Handling
+
+- Always `await` promises — never leave a promise floating without error handling
+- Use `try/catch` around `await` calls only when you can handle or enrich the error meaningfully
+- Let unhandled errors propagate to the global exception filter — do NOT catch-and-rethrow without adding context
+- Register a global `process.on('unhandledRejection')` handler that logs and exits with code 1
+
+## Logging
+
+- Log errors with structured context: `logger.error('Payment failed', { orderId, userId, error })`
+- Use severity levels consistently: `error` for failures, `warn` for degraded state, `info` for business events, `debug` for troubleshooting
+- Never log sensitive data: passwords, tokens, credit card numbers, PII
+- Include correlation IDs in all log entries for request tracing across services
+- Use NestJS `Logger` or a structured logger (Pino, Winston) — do NOT use `console.log` in production
+
+## Principles
+
+- Never swallow errors silently — at minimum log them before deciding to continue
+- Fail fast on startup: missing config, unreachable database, invalid schema should crash the process
+- Recoverable vs. fatal: retry transient failures (network timeout); crash on programmer errors (type mismatch)
+- Return domain errors from services; let the transport layer (controller, message handler) decide the response format
+- Use `Result<T, E>` pattern (or NestJS exception filters) — do NOT use error codes in return values

--- a/language-packs/node/rules/hexagonal-architecture.md
+++ b/language-packs/node/rules/hexagonal-architecture.md
@@ -1,0 +1,62 @@
+---
+paths: ["**/*.ts", "**/*.module.ts", "**/*.port.ts", "**/*.adapter.ts"]
+---
+
+# Hexagonal Architecture (Ports & Adapters)
+
+## Layer Structure
+
+- Three layers: **Domain** (core), **Application** (use cases), **Infrastructure** (adapters)
+- Domain layer has zero dependencies on frameworks, ORMs, or HTTP — pure TypeScript only
+- Application layer depends on Domain; defines ports (interfaces) for external interactions
+- Infrastructure layer implements ports — ORM repositories, HTTP clients, message producers
+- No layer may import from a layer above it: Infrastructure -> Application -> Domain (dependency flows inward)
+
+## Folder Organisation
+
+```
+src/
+  <feature>/
+    domain/          # Entities, value objects, domain services, domain events
+    application/     # Use cases, ports (interfaces), DTOs, application services
+    infrastructure/  # Adapters (repositories, HTTP, messaging), module registration
+```
+
+- One folder per bounded context / feature — do NOT flatten all entities into a single `domain/` folder
+- Keep `domain/` free of decorators from NestJS, TypeORM, Prisma, or any framework
+
+## Ports (Interfaces)
+
+- Define ports as TypeScript interfaces in the `application/` layer
+- Name ports by capability: `UserRepository`, `EmailSender`, `PaymentGateway` — not by implementation
+- Ports describe WHAT, not HOW — no ORM types, HTTP details, or framework specifics in port signatures
+- Use `InjectionToken` to bind ports to concrete adapters in the NestJS module
+
+## Adapters (Implementations)
+
+- One adapter per external system — database, HTTP API, message broker, file system
+- Adapters live in `infrastructure/` and implement a port interface
+- Adapters may depend on framework libraries (TypeORM, Prisma, Axios) — the domain must not
+- Adapters translate between domain types and external formats (DB rows, API responses, messages)
+
+## Dependency Rule
+
+- Domain imports: nothing external (only other domain types)
+- Application imports: domain types + port interfaces it defines
+- Infrastructure imports: application ports + framework libraries to implement them
+- Controllers / entry points live in infrastructure — they call application use cases, not domain directly
+- Never pass ORM entities across layer boundaries — map to DTOs or domain objects at the adapter
+
+## Use Cases
+
+- One class per use case: `CreateUserUseCase`, `ProcessPaymentUseCase`
+- Use cases orchestrate domain logic and call ports — they do NOT contain business rules themselves
+- Use cases receive and return DTOs — never domain entities (prevents leaking internal structure)
+- Use cases are the only entry point for application logic — controllers and message handlers call use cases
+
+## Testing Implications
+
+- Domain layer: unit tests with zero mocks (pure logic)
+- Application layer: unit tests with mocked ports (verify orchestration)
+- Infrastructure layer: integration tests against real external systems (Testcontainers, test SMTP)
+- Never mock the domain — if you need to mock domain logic, the boundaries are wrong

--- a/language-packs/node/rules/nestjs-conventions.md
+++ b/language-packs/node/rules/nestjs-conventions.md
@@ -1,0 +1,59 @@
+---
+paths: ["**/*.ts", "**/*.module.ts", "**/*.controller.ts", "**/*.service.ts"]
+---
+
+# NestJS Conventions
+
+## Modules
+
+- One module per bounded context — do NOT create a single `SharedModule` dumping ground
+- Import only what the module needs — no wildcard re-exports
+- Use `forRoot()` / `forRootAsync()` for singleton configuration modules (database, config, auth)
+- Use `forFeature()` for feature-scoped registrations (TypeORM entities, Mongoose schemas)
+- Global modules (`@Global()`) only for cross-cutting concerns (config, logging) — never for business logic
+
+## Dependency Injection
+
+- Constructor injection only — do NOT use property injection (`@Inject()` on fields)
+- Declare all injected dependencies `private readonly`
+- Use custom `InjectionToken` for swappable implementations — do NOT inject concrete classes for ports
+- Use `@Optional()` only for genuinely optional dependencies, not to hide missing providers
+- Scope: default singleton; use `REQUEST` scope only when request-specific state is unavoidable (it disables singleton optimisation)
+
+## Controllers
+
+- One controller per resource/aggregate — do NOT combine unrelated endpoints
+- Use `@Controller('resource')` with plural, kebab-case route prefix
+- Return DTOs — never expose domain entities or ORM models directly
+- Use `@HttpCode()` for non-200 success responses (e.g., 201 for create, 204 for delete)
+- Validate all input with `class-validator` decorators + `ValidationPipe` globally
+- No business logic in controllers — delegate to services immediately
+
+## Services
+
+- One service per domain operation or aggregate — keep single-responsibility
+- Throw domain-specific exceptions — do NOT throw raw `HttpException` from services
+- Services must not depend on HTTP concepts (Request, Response, headers)
+- Use `@Injectable()` on all services — even if currently only used in one module
+
+## Exception Handling
+
+- Register a global `@Catch()` exception filter for consistent error responses
+- Map domain exceptions to HTTP status codes in the exception filter — not in services
+- Return consistent error shape: `{ statusCode, message, error, timestamp }`
+- Log all 5xx errors with full stack trace; log 4xx at debug level
+- Never expose internal error details (stack traces, SQL errors) in production responses
+
+## Pipes, Guards, Interceptors
+
+- Use `ValidationPipe` globally (`app.useGlobalPipes()`) — do NOT apply per-route unless overriding
+- Guards for authorisation (`@UseGuards()`) — do NOT check permissions in controllers manually
+- Interceptors for cross-cutting: logging, caching, response transformation
+- Execution order: Middleware -> Guards -> Interceptors -> Pipes -> Handler -> Interceptors -> Filters
+
+## Configuration
+
+- Use `@nestjs/config` with `ConfigService` — do NOT read `process.env` directly in services
+- Validate config at startup with Joi or `class-validator` schema — fail fast on missing values
+- Use `.env` files for local development only — never commit them
+- Type config access: `configService.get<number>('PORT')` with explicit type parameter

--- a/language-packs/node/rules/node-conventions.md
+++ b/language-packs/node/rules/node-conventions.md
@@ -40,5 +40,5 @@ paths: ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"]
 - No `console.log` in production code — use a structured logger (NestJS Logger, Pino)
 - No magic numbers or strings — extract to named constants or config
 - Functions should do one thing — if a function has `and` in its name, split it
-- Maximum function length: aim for <30 lines; extract helpers for complex logic
+- Maximum function length: 30 lines — extract helpers when a function exceeds this
 - Prefer early returns over deeply nested conditionals

--- a/language-packs/node/rules/node-conventions.md
+++ b/language-packs/node/rules/node-conventions.md
@@ -2,9 +2,43 @@
 paths: ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"]
 ---
 
-# Node.js Conventions
+# Node.js / TypeScript Conventions
 
-- Use const by default, let when needed, never var
-- Async/await over raw promises
-- Named exports over default exports
-- Destructure function parameters for clarity
+## Language
+
+- Use `const` by default, `let` when reassignment is needed, never `var`
+- Async/await over raw promises — no `.then()` chains in new code
+- Named exports over default exports — improves refactoring and auto-import
+- Destructure function parameters for clarity: `({ userId, limit }: FetchOptions)`
+- Strict equality (`===` / `!==`) everywhere — never `==` / `!=`
+
+## TypeScript
+
+- Enable `strict: true` in `tsconfig.json` — all public APIs must have explicit types
+- No `any` without a `// SAFETY:` comment justifying why `unknown` is insufficient
+- Use `unknown` for values of uncertain type — narrow with type guards
+- Use discriminated unions over type assertions for control flow
+- Barrel files (`index.ts`) for public API boundaries only — do NOT barrel internal modules
+
+## Modules
+
+- Use ES modules (`import` / `export`) — no `require()` in TypeScript
+- Organise imports: Node builtins -> external packages -> internal modules (enforce via ESLint)
+- Avoid circular imports — if two modules import each other, extract the shared type to a third module
+- Use path aliases (`@app/`, `@modules/`) configured in `tsconfig.json` paths — no deep relative imports (`../../../`)
+
+## NestJS Specifics
+
+- File naming: `<name>.<type>.ts` — e.g., `user.controller.ts`, `user.service.ts`, `user.module.ts`
+- One class per file — do NOT combine controllers, services, or DTOs in a single file
+- DTOs: use `class-validator` decorators for validation, `class-transformer` for serialisation
+- Use `readonly` on DTO properties — DTOs are immutable data carriers
+- Enums: use string enums for API contracts — they serialise readably and survive refactoring
+
+## Code Quality
+
+- No `console.log` in production code — use a structured logger (NestJS Logger, Pino)
+- No magic numbers or strings — extract to named constants or config
+- Functions should do one thing — if a function has `and` in its name, split it
+- Maximum function length: aim for <30 lines; extract helpers for complex logic
+- Prefer early returns over deeply nested conditionals

--- a/language-packs/node/rules/orm-patterns.md
+++ b/language-packs/node/rules/orm-patterns.md
@@ -1,0 +1,58 @@
+---
+paths: ["**/*.ts", "**/*.entity.ts", "**/*.schema.ts", "**/*.repository.ts", "**/migrations/**"]
+---
+
+# ORM & Database Patterns
+
+## Query Safety
+
+- Always use parameterised queries — never interpolate user input into SQL or query builders
+- Use ORM query builders or prepared statements — no raw string concatenation
+- Validate and sanitise all user-provided identifiers (column names, sort fields) against an allowlist
+- Limit `SELECT` to needed columns — no `SELECT *` in production queries
+
+## Migrations
+
+- Every schema change goes through a migration — no manual DDL or `synchronize: true` in production
+- Migrations are append-only — never edit a migration that has been applied to shared environments
+- Name migrations descriptively: `1713000000000-AddUserEmailIndex`
+- Test migrations against a real database before merging — not just TypeScript compilation
+- Include both `up()` and `down()` — reversibility is required for safe rollbacks
+- Run migrations in CI against a disposable database (Testcontainers or Docker)
+
+## TypeORM
+
+- Use `Repository` pattern via `@InjectRepository()` — do NOT use `EntityManager` directly for CRUD
+- Define entities with decorators; use `@Column({ type: '...' })` with explicit DB types
+- Default all relations to lazy (`{ lazy: true }`) or load explicitly with `relations` option — prevent N+1
+- Use `QueryBuilder` for complex queries; use `Repository` methods for simple CRUD
+- Transaction: `dataSource.transaction(async (manager) => { ... })` — do NOT nest transactions
+
+## Prisma
+
+- Use `schema.prisma` as the single source of truth — do NOT define models elsewhere
+- Generate client after every schema change: `npx prisma generate`
+- Use `prisma.$transaction()` for multi-step writes — not manual rollback logic
+- Access relations via Prisma's fluent API — do NOT write raw JOINs unless performance-critical
+- Use `@map` / `@@map` for snake_case DB columns with camelCase TS fields
+
+## Drizzle
+
+- Schema-first: define tables in TypeScript with `pgTable()` / `mysqlTable()` / `sqliteTable()`
+- Use Drizzle Kit for migration generation: `npx drizzle-kit generate`
+- Prefer the relational query API (`db.query.users.findMany()`) over raw SQL builders for readability
+- Use `$inferSelect` / `$inferInsert` to derive types from schema — do NOT duplicate type definitions
+
+## Connection Management
+
+- Use connection pooling — do NOT create a new connection per request
+- Set pool size based on expected concurrency (default: 10 for most Node apps)
+- Handle connection errors with retry logic at startup — fail fast if database is unreachable
+- Close connections gracefully on application shutdown (`onModuleDestroy` in NestJS)
+
+## Performance
+
+- Add indexes for columns used in `WHERE`, `ORDER BY`, and `JOIN` clauses
+- Use pagination (`LIMIT` / `OFFSET` or cursor-based) for list endpoints — never return unbounded result sets
+- Profile slow queries in development with query logging enabled
+- Use database-level constraints (UNIQUE, NOT NULL, FK) — do NOT rely only on application-level validation

--- a/language-packs/node/rules/orm-patterns.md
+++ b/language-packs/node/rules/orm-patterns.md
@@ -46,7 +46,7 @@ paths: ["**/*.ts", "**/*.entity.ts", "**/*.schema.ts", "**/*.repository.ts", "**
 ## Connection Management
 
 - Use connection pooling — do NOT create a new connection per request
-- Set pool size based on expected concurrency (default: 10 for most Node apps)
+- Set pool size based on expected concurrency — default to 10 connections
 - Handle connection errors with retry logic at startup — fail fast if database is unreachable
 - Close connections gracefully on application shutdown (`onModuleDestroy` in NestJS)
 

--- a/language-packs/node/rules/testing.md
+++ b/language-packs/node/rules/testing.md
@@ -7,7 +7,7 @@ paths: ["**/*.test.ts", "**/*.spec.ts", "**/*.test.js", "**/*.spec.js", "test/**
 ## Structure
 
 - Follow Arrange-Act-Assert (AAA) pattern — separate setup, execution, and verification
-- One assertion per test when possible — each test verifies one behaviour
+- One assertion per test — each test verifies one behaviour
 - Descriptive test names: `should return 404 when user does not exist` — not `test1` or `works`
 - Group related tests with `describe` blocks matching the class or function under test
 
@@ -17,7 +17,7 @@ paths: ["**/*.test.ts", "**/*.spec.ts", "**/*.test.js", "**/*.spec.js", "test/**
 - Prefer `toEqual()` for object/array comparison, `toBe()` for primitives and references
 - Use `toThrow()` / `rejects.toThrow()` for error assertions — do NOT wrap in try/catch
 - Clean up mocks in `afterEach`: `jest.restoreAllMocks()` — prevent leakage between tests
-- Avoid `jest.mock()` at module level when `jest.spyOn()` in the test body suffices — module mocks are harder to reason about
+- Use `jest.spyOn()` in the test body — do NOT use `jest.mock()` at module level unless the dependency has no injectable seam
 
 ## NestJS Testing
 
@@ -44,7 +44,7 @@ paths: ["**/*.test.ts", "**/*.spec.ts", "**/*.test.js", "**/*.spec.js", "test/**
 
 ## Coverage
 
-- Aim for meaningful coverage, not a number — 80% with tested edge cases beats 95% of trivial assertions
+- Cover all public API paths, error branches, and boundary conditions — do NOT chase a coverage percentage with trivial assertions
 - Always test: error paths, boundary conditions, authorisation checks
 - Do NOT test: framework internals (NestJS DI, TypeORM queries), third-party library behaviour
 - Use `--collectCoverageFrom` to scope coverage to source files — exclude config, migrations, generated code

--- a/language-packs/node/rules/testing.md
+++ b/language-packs/node/rules/testing.md
@@ -1,0 +1,57 @@
+---
+paths: ["**/*.test.ts", "**/*.spec.ts", "**/*.test.js", "**/*.spec.js", "test/**/*", "tests/**/*"]
+---
+
+# Testing Conventions (Jest / NestJS)
+
+## Structure
+
+- Follow Arrange-Act-Assert (AAA) pattern — separate setup, execution, and verification
+- One assertion per test when possible — each test verifies one behaviour
+- Descriptive test names: `should return 404 when user does not exist` — not `test1` or `works`
+- Group related tests with `describe` blocks matching the class or function under test
+
+## Jest
+
+- Use `jest.fn()` for function mocks, `jest.spyOn()` to intercept existing methods
+- Prefer `toEqual()` for object/array comparison, `toBe()` for primitives and references
+- Use `toThrow()` / `rejects.toThrow()` for error assertions — do NOT wrap in try/catch
+- Clean up mocks in `afterEach`: `jest.restoreAllMocks()` — prevent leakage between tests
+- Avoid `jest.mock()` at module level when `jest.spyOn()` in the test body suffices — module mocks are harder to reason about
+
+## NestJS Testing
+
+- Use `Test.createTestingModule()` for unit and integration tests
+- Override providers with `.overrideProvider(TOKEN).useValue(mockImpl)` — do NOT mock the entire module
+- Use `.compile()` and `module.get<ServiceType>(ServiceType)` to retrieve the subject under test
+- For e2e tests: use `supertest` with `app.getHttpServer()` — test full HTTP request/response cycle
+- Use `INestApplication` lifecycle: call `app.init()` in `beforeAll`, `app.close()` in `afterAll`
+
+## Mocking Strategy
+
+- Mock external dependencies (database, HTTP, file system) — not internal domain logic
+- Use in-memory implementations for repositories in unit tests — not ORM mocks
+- For database integration tests: use Testcontainers with a real database instance
+- Never mock what you own — if you need to mock a service you wrote, the dependency graph is too tight
+- Prefer dependency injection over `jest.mock()` — inject test doubles via the module builder
+
+## Test Organisation
+
+- Co-locate unit tests: `user.service.spec.ts` next to `user.service.ts`
+- Place e2e tests in `test/` at project root: `test/user.e2e-spec.ts`
+- Shared test fixtures in `test/fixtures/` — reusable factory functions, not raw JSON
+- Shared test utilities in `test/helpers/` — custom matchers, test database setup
+
+## Coverage
+
+- Aim for meaningful coverage, not a number — 80% with tested edge cases beats 95% of trivial assertions
+- Always test: error paths, boundary conditions, authorisation checks
+- Do NOT test: framework internals (NestJS DI, TypeORM queries), third-party library behaviour
+- Use `--collectCoverageFrom` to scope coverage to source files — exclude config, migrations, generated code
+
+## Performance
+
+- Keep unit tests fast (<5ms each) — mock all I/O
+- Parallelise test suites with Jest workers (default behaviour) — do NOT use `--runInBand` unless tests share state
+- Use `beforeAll` for expensive setup (database seeding, app bootstrap) — not `beforeEach`
+- Tag slow integration tests and run them separately in CI


### PR DESCRIPTION
## Summary
- Expands `node-conventions.md` from 4 basic rules to full TypeScript/NestJS conventions (language, TS strict, modules, NestJS specifics, code quality)
- Adds `nestjs-conventions.md` — modules, DI, controllers, services, exception filters, pipes/guards/interceptors, config
- Adds `orm-patterns.md` — query safety, migrations, TypeORM/Prisma/Drizzle patterns, connection management
- Adds `hexagonal-architecture.md` — layer structure, ports & adapters, dependency rule, use cases
- Adds `error-handling.md` — custom error classes, error hierarchy, async handling, logging
- Adds `testing.md` — Jest, NestJS testing module, mocking strategy, test organisation, coverage

Closes the remaining 5 ACs in the "Node Language Pack Rules" section of #240.

## Test plan
- [x] `bash tests/run-all.sh` — 19/21 (same 2 pre-existing failures: 07-agent-permissions, 21-snapshot-regression)
- [x] All 6 rule files have YAML frontmatter with `paths:` glob
- [x] Style matches Spring Boot / Angular rule files (imperative, DO/DON'T format)
- [x] `install.sh` already copies `language-packs/$CC_LANGUAGE/rules/*.md` — no installer changes needed