### PR TITLE
fix(install): escape $1 in generated conf to prevent unbound variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -258,6 +258,11 @@ else
     CC_UPDATE_AUTO_CHECK="true"
     CC_UPDATE_CHECK_INTERVAL="7"
 
+    # Escape $ in command values so the generated conf can be safely re-sourced
+    CC_LINT_COMMAND="${CC_LINT_COMMAND//\$/\\\$}"
+    CC_TEST_COMMAND="${CC_TEST_COMMAND//\$/\\\$}"
+    CC_FORMAT_COMMAND="${CC_FORMAT_COMMAND//\$/\\\$}"
+
     # Write config file
     info "Writing configuration to ${CONF_FILE}"
     cat > "$CONF_FILE" << CONFEOF

--- a/update.sh
+++ b/update.sh
@@ -243,10 +243,24 @@ header "Checking for new framework files"
 # Load config to know which components are installed
 CONF_FILE="${PROJECT_DIR}/cognitive-core.conf"
 CONF_ALT="${PROJECT_DIR}/.claude/cognitive-core.conf"
+
+# Migration: fix unescaped $1 in command variables (pre-1.6.0 installs)
+# Without this, sourcing the conf under set -u fails with "unbound variable"
+_cc_fix_unescaped_dollar() {
+    local f="$1"
+    if grep -qE '^CC_(LINT|TEST|FORMAT)_COMMAND="[^"]*[^\\]\$[0-9]' "$f" 2>/dev/null; then
+        sed -i.bak -E 's/^(CC_(LINT|TEST|FORMAT)_COMMAND="[^"]*[^\\])\$([0-9])/\1\\$\3/g' "$f"
+        rm -f "${f}.bak"
+        info "Migrated: escaped \$N in command variables in $(basename "$f")"
+    fi
+}
+
 if [ -f "$CONF_FILE" ]; then
+    _cc_fix_unescaped_dollar "$CONF_FILE"
     # shellcheck disable=SC1090
     source "$CONF_FILE"
 elif [ -f "$CONF_ALT" ]; then
+    _cc_fix_unescaped_dollar "$CONF_ALT"
     # shellcheck disable=SC1090
     source "$CONF_ALT"
 fi


### PR DESCRIPTION
## Summary

- `install.sh` now escapes `$` in `CC_LINT_COMMAND`, `CC_TEST_COMMAND`, `CC_FORMAT_COMMAND` before writing the unquoted heredoc, so generated conf files contain `\$1` instead of bare `$1`
- `update.sh` adds a migration step that patches existing broken conf files in-place before sourcing them — fixes all pre-1.6.0 installations on next update
- Migration is idempotent (already-correct files are skipped) and cross-platform (`sed -i.bak` works on both macOS and Linux)

Closes #244

## Test plan

- [x] Verified generated conf sources cleanly under `set -u`
- [x] Verified `$1` substitution in `post-edit-lint.sh` still works after round-trip
- [x] Verified migration is idempotent (already-escaped files untouched)
- [x] Verified `sed -i.bak` on macOS Darwin 23.6.0
- [x] All test suites pass (16/21 — 5 pre-existing failures unrelated to this change)
- [x] Acceptance criteria verified: 5/5 PASS (see issue comment)