### PR TITLE
chore(hooks): disable default Co-Authored-By trailer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,5 +80,6 @@
   "env": {
     "CC_PROJECT_NAME": "cognitive-core",
     "CC_AGENT_TEAMS": "false"
-  }
+  },
+  "includeCoAuthoredBy": false
 }

--- a/core/templates/settings.json.tmpl
+++ b/core/templates/settings.json.tmpl
@@ -130,5 +130,6 @@
   "env": {
     "CC_PROJECT_NAME": "{{CC_PROJECT_NAME}}",
     "CC_AGENT_TEAMS": "{{CC_AGENT_TEAMS}}"
-  }
+  },
+  "includeCoAuthoredBy": false
 }

--- a/docs/sessions/2026-04-16-conf-escaping-and-board-hygiene.md
+++ b/docs/sessions/2026-04-16-conf-escaping-and-board-hygiene.md
@@ -1,0 +1,74 @@
+# Session: 2026-04-16 — Conf Escaping, Board Hygiene, Test Investigation
+
+## Completed
+
+### fix(install): unescaped $1 in generated conf (#244) — DONE
+
+**Problem**: `install.sh` generates `cognitive-core.conf` with unescaped `$1` in command variables (e.g. `CC_LINT_COMMAND="eslint $1"`). When sourced under `set -u`, bash throws `unbound variable`.
+
+**Root cause**: Unquoted heredoc (`<< CONFEOF`) expands `$1` when writing conf. The case statement uses single quotes correctly, but the heredoc pass-through strips the protection.
+
+**Fix** (2 files, 19 lines):
+- `install.sh`: Escapes `$` in `CC_LINT_COMMAND`, `CC_TEST_COMMAND`, `CC_FORMAT_COMMAND` before heredoc write
+- `update.sh`: Migration `_cc_fix_unescaped_dollar()` patches existing broken conf files before sourcing — idempotent, cross-platform (`sed -i.bak`)
+
+**Also fixed**: `brigadee/cognitive-core.conf` patched directly (`"eslint $1"` → `"eslint \$1"`)
+
+**Status**: PR #249 merged, issue #244 approved and moved to Done.
+
+### chore(hooks): disable default Co-Authored-By (#232 partial)
+
+**Problem**: Claude Code adds default `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>` trailer, violating CLAUDE.md rule 7 ("NO AI references").
+
+**Fix**: Set `includeCoAuthoredBy: false` in:
+- `.claude/settings.json` (this project)
+- `core/templates/settings.json.tmpl` (all future installations)
+
+**Status**: PR #251 open on branch `chore/232-disable-default-coauthored-by`. Ready for merge.
+
+## Created (not started)
+
+### feat(hooks): pre-commit board hygiene guard (#245) — Backlog
+
+Full architecture designed and reviewed from testability, performance, usability, and stochastic vulnerability perspectives. Key decisions:
+- Separate hook (`validate-commit.sh`), not inline in `validate-bash.sh`
+- Flat TSV cache (no jq in hot path), refreshed at session start
+- Three deterministic states: allow / deny / ask — no silent fail-open
+- Network/API issues escalate to `ask` ("validate manually"), never silently allow
+- Pure decision function `_cc_board_validate()` for testability
+- 24 acceptance criteria, 38 test cases defined in ticket
+
+### Test suite failures investigated (#246, #247, #248) — Backlog
+
+Investigated all 5 pre-existing test suite failures (07, 12, 14, 16, 21). Found 3 root causes:
+
+| Issue | Root Cause | Suites | Priority |
+|-------|-----------|--------|----------|
+| #246 | SIGPIPE race: `echo \| grep -q` + `pipefail` on large inputs | 07, 14 | P1 |
+| #247 | `timeout`/`md5sum` missing on macOS | 12, 14, 21 | P2 |
+| #248 | Stale external file assertions in suite 16 | 16 | P3 |
+
+**#246 fix** is 2 lines in `test-helpers.sh`: replace `echo "$haystack" | grep -qF` with `grep -qF "$needle" <<< "$haystack"` (herestring avoids SIGPIPE). This fixes the systemic issue across all suites.
+
+## Open Branches
+
+| Branch | PR | Status |
+|--------|-----|--------|
+| `chore/232-disable-default-coauthored-by` | #251 | Open, ready for merge |
+| `fix/244-conf-unescaped-dollar` | #249 | Merged |
+
+## Current State
+
+- On branch: `chore/232-disable-default-coauthored-by`
+- Working tree: clean
+- Main is up to date (includes #244 merge)
+
+## Board Summary
+
+| Issue | Status | Column |
+|-------|--------|--------|
+| #244 | Closed | Done |
+| #245 | Open | Backlog |
+| #246 | Open | Backlog |
+| #247 | Open | Backlog |
+| #248 | Open | Backlog |

--- a/docs/sessions/2026-04-16-continuation-prompt.md
+++ b/docs/sessions/2026-04-16-continuation-prompt.md
@@ -1,0 +1,35 @@
+# Continuation Prompt — 2026-04-16
+
+Paste this into a new Claude Code session on the other machine after `git pull`.
+
+---
+
+Read the session document at `docs/sessions/2026-04-16-conf-escaping-and-board-hygiene.md` for full context. Here is what needs to happen next:
+
+## Immediate (this session)
+
+1. **Merge PR #251** (`chore/232-disable-default-coauthored-by`) — sets `includeCoAuthoredBy: false` in settings.json and template. Review, merge, switch back to main.
+
+2. **Fix #246** (P1 — SIGPIPE race in test-helpers.sh) — 2-line fix in `tests/lib/test-helpers.sh`:
+   - `assert_contains()` line 125: replace `echo "$haystack" | grep -qF "$needle"` with `grep -qF "$needle" <<< "$haystack"`
+   - `assert_not_contains()` line 134: same pattern
+   - This fixes flaky suite 07 and deterministic failures in suite 14 (6 SKILL.md assertions)
+   - Create branch `fix/246-sigpipe-assert-contains`, commit, push, PR, verify suites 07 and 14 pass
+
+3. **Fix #247** (P2 — macOS timeout/md5sum) — portable wrappers needed:
+   - Suite 21: `md5sum` → `md5 -r` on macOS fallback
+   - Suite 12: `timeout` → skip with `_skip` if unavailable (or use perl alarm fallback)
+   - Suite 14 ReDoS test: same timeout fix
+   - Create branch `fix/247-macos-test-portability`
+
+4. **Fix #248** (P3 — suite 16 stale assertions) — remove or skip the external file validation section at lines 169-183 in `tests/suites/16-recursive-epic-structure.sh`. The synthetic tests (lines 1-167) already cover structural validation.
+
+## After test fixes
+
+5. **Run `bash tests/run-all.sh`** — target: 21/21 suites passing
+
+## Backlog
+
+6. **#245** (board hygiene hook) — full architecture and AC defined in the ticket. Ready for implementation when prioritized. Size:M, ~200 lines across 4 files.
+
+7. **#232** (custom Co-Authored-By trailer) — the `includeCoAuthoredBy: false` is a stopgap. The full `prepare-commit-msg` hook with `CC_COAUTHOR_LINE` config is still pending.


### PR DESCRIPTION
## Summary

- Set `includeCoAuthoredBy: false` in `.claude/settings.json` (this project)
- Set `includeCoAuthoredBy: false` in `core/templates/settings.json.tmpl` (all future installations)

Enforces CLAUDE.md rule 7 ("NO AI references" in commits) deterministically via Claude Code config rather than manual discipline. Partial progress toward #232 — the full custom `CC_COAUTHOR_LINE` hook is still pending.

## Test plan

- [x] Verified setting is valid JSON in both files
- [x] No test suite impact (setting is Claude Code runtime config, not tested by framework)