### PR TITLE
fix(tests): SIGPIPE race, macOS portability, stale suite 16

### DIFF
--- a/tests/baselines/claude.snapshot
+++ b/tests/baselines/claude.snapshot
@@ -4,7 +4,7 @@
 cc82b99c354b66bc8d4603467f0e69c1	./.claude/cognitive-core/check-update.sh
 2fc08fe8f49e21e94118f1a82877a374	./.claude/cognitive-core/context-cleanup.sh
 9d9bcd18cfc0ea29ab5b2c17b510c6e5	./.claude/cognitive-core/health-check.sh
-c897d8b18a84226344b2f2b39838afb5	./.claude/cognitive-core/version.json
+743ebd4b7f27f53456927b73a33eca0d	./.claude/cognitive-core/version.json
 47b561a9cb3594c789ecad8b6b8e6766	./.claude/compact-rules.md
 7f3cfa96a9afa2db9b937b1e32cb56a0	./.claude/fitness-checks.sh
 93a614f0d620a8305b6f7ed86bf2ad36	./.claude/gitattributes-lang
@@ -17,7 +17,7 @@ eac03d16cbdd4ceef2315e5a7636610f	./.claude/lint-config.sh
 32b985614c82a57c14f6c591195c0976	./.claude/pack.conf
 37eac1618a1be7916fd3b44ef3e1d4d6	./.claude/rules/python-conventions.md
 92972f447392de6b71634fb27131d7ef	./.claude/rules/testing.md
-ef49cb9d357f0de688c0ab057794eaa0	./.claude/settings.json
+b94e5fa6305fbb7ebeaeee5d83d14e52	./.claude/settings.json
 4c59165d7098ce6d3c70c21a8b389f51	./.claude/skills/code-review/SKILL.md
 70f66bca776ab7aefe90967e737a8c00	./.claude/skills/python-ddd/SKILL.md
 2514df37297b50522e04cfa75efeee92	./.claude/skills/python-messaging/SKILL.md

--- a/tests/lib/test-helpers.sh
+++ b/tests/lib/test-helpers.sh
@@ -122,7 +122,7 @@ assert_ne() {
 
 assert_contains() {
     local label="$1" haystack="$2" needle="$3"
-    if echo "$haystack" | grep -qF "$needle"; then
+    if grep -qF "$needle" <<< "$haystack"; then
         _pass "$label"
     else
         _fail "$label" "output does not contain '${needle}'"
@@ -131,7 +131,7 @@ assert_contains() {
 
 assert_not_contains() {
     local label="$1" haystack="$2" needle="$3"
-    if ! echo "$haystack" | grep -qF "$needle"; then
+    if ! grep -qF "$needle" <<< "$haystack"; then
         _pass "$label"
     else
         _fail "$label" "output should not contain '${needle}'"
@@ -140,7 +140,7 @@ assert_not_contains() {
 
 assert_matches() {
     local label="$1" haystack="$2" pattern="$3"
-    if echo "$haystack" | grep -qE "$pattern"; then
+    if grep -qE "$pattern" <<< "$haystack"; then
         _pass "$label"
     else
         _fail "$label" "output does not match regex '${pattern}'"
@@ -213,10 +213,10 @@ assert_hook_denies() {
     local label="$1" hook_script="$2" stdin_json="$3"
     local output
     output=$(echo "$stdin_json" | bash "$hook_script" 2>/dev/null) || true
-    if echo "$output" | grep -q '"permissionDecision".*"deny"'; then
+    if grep -q '"permissionDecision".*"deny"' <<< "$output"; then
         _pass "$label"
     else
-        _fail "$label" "expected deny decision, got: $(echo "$output" | head -1)"
+        _fail "$label" "expected deny decision, got: $(head -1 <<< "$output")"
     fi
 }
 
@@ -224,10 +224,10 @@ assert_hook_allows() {
     local label="$1" hook_script="$2" stdin_json="$3"
     local output
     output=$(echo "$stdin_json" | bash "$hook_script" 2>/dev/null) || true
-    if [ -z "$output" ] || ! echo "$output" | grep -q '"permissionDecision".*"deny"'; then
+    if [ -z "$output" ] || ! grep -q '"permissionDecision".*"deny"' <<< "$output"; then
         _pass "$label"
     else
-        _fail "$label" "expected allow (no deny), got: $(echo "$output" | head -1)"
+        _fail "$label" "expected allow (no deny), got: $(head -1 <<< "$output")"
     fi
 }
 
@@ -235,10 +235,10 @@ assert_hook_asks() {
     local label="$1" hook_script="$2" stdin_json="$3"
     local output
     output=$(echo "$stdin_json" | bash "$hook_script" 2>/dev/null) || true
-    if echo "$output" | grep -q '"permissionDecision".*"ask"'; then
+    if grep -q '"permissionDecision".*"ask"' <<< "$output"; then
         _pass "$label"
     else
-        _fail "$label" "expected ask decision, got: $(echo "$output" | head -1)"
+        _fail "$label" "expected ask decision, got: $(head -1 <<< "$output")"
     fi
 }
 
@@ -282,4 +282,33 @@ mock_write_json() {
 # Create a temp directory for test isolation
 create_test_dir() {
     mktemp -d "${TMPDIR:-/tmp}/cc-test-XXXXXX"
+}
+
+# ---- Portable command wrappers (macOS + Linux) ----
+
+# Portable md5 checksum: outputs "hash  filename" like md5sum
+_portable_md5() {
+    if command -v md5sum &>/dev/null; then
+        md5sum "$@"
+    elif command -v md5 &>/dev/null; then
+        md5 -r "$@"
+    else
+        _skip "no md5sum or md5 available"
+        return 1
+    fi
+}
+
+# Portable timeout: gtimeout (Homebrew) → perl fallback → skip
+_portable_timeout() {
+    local seconds="$1"; shift
+    if command -v gtimeout &>/dev/null; then
+        gtimeout "$seconds" "$@"
+    elif command -v timeout &>/dev/null; then
+        timeout "$seconds" "$@"
+    elif command -v perl &>/dev/null; then
+        perl -e 'alarm shift; exec @ARGV' "$seconds" "$@"
+    else
+        _skip "no timeout, gtimeout, or perl available"
+        return 1
+    fi
 }

--- a/tests/suites/12-mcp-server.sh
+++ b/tests/suites/12-mcp-server.sh
@@ -49,7 +49,7 @@ mcp_request() {
     local request="$1"
     local timeout="${2:-5}"
     # Send the request, then close stdin so server exits
-    echo "$request" | timeout "$timeout" python3 "$MCP_SERVER" 2>/dev/null || true
+    echo "$request" | _portable_timeout "$timeout" python3 "$MCP_SERVER" 2>/dev/null || true
 }
 
 # ---- Test: MCP server responds to initialize ----

--- a/tests/suites/14-project-board-providers.sh
+++ b/tests/suites/14-project-board-providers.sh
@@ -1394,7 +1394,7 @@ fi
 
 # T17: ReDoS safety — 10KB input without timeout
 big_input=$(python3 -c "print('spring-cloud-starter-config ' * 500)")
-adf_out=$(timeout 5 bash -c "
+adf_out=$(_portable_timeout 5 bash -c "
     set -euo pipefail
     export CC_JIRA_URL='https://test.atlassian.net'
     export CC_JIRA_PROJECT='TEST'

--- a/tests/suites/16-recursive-epic-structure.sh
+++ b/tests/suites/16-recursive-epic-structure.sh
@@ -5,8 +5,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/../lib/test-helpers.sh"
 
@@ -166,20 +164,7 @@ assert_not_contains \
     "$SUB_BAD" \
     "**Parent**:"
 
-# ================================================================
-# Validate actual EU AI Act recursive epic (if co-located)
-# ================================================================
-EPIC_FILE="${ROOT_DIR}/../dev-notes/docs/research/2026-03-21-eu-ai-act-recursive-epic.md"
-if [ -f "$EPIC_FILE" ]; then
-    EPIC_CONTENT=$(cat "$EPIC_FILE")
-    assert_contains "Actual epic has dependency graph" "$EPIC_CONTENT" "Dependency Graph"
-    assert_contains "Actual epic has dependency matrix" "$EPIC_CONTENT" "Dependency Matrix"
-    assert_contains "Actual epic references parent #120" "$EPIC_CONTENT" "#120"
-    assert_contains "Actual epic references sub-issue #121" "$EPIC_CONTENT" "#121"
-    assert_contains "Actual epic has effort summary" "$EPIC_CONTENT" "Effort Summary"
-    assert_contains "Actual epic has GitHub links" "$EPIC_CONTENT" "github.com/mindcockpit-ai/cognitive-core/issues"
-else
-    _skip "EU AI Act recursive epic not found (dev-notes may not be co-located)"
-fi
+# External file validation removed (#248) — tests must not depend on
+# content outside the repo. Synthetic tests above cover structure.
 
 suite_end

--- a/tests/suites/21-snapshot-regression.sh
+++ b/tests/suites/21-snapshot-regression.sh
@@ -108,7 +108,7 @@ _capture_snapshot() {
                 sed -e 's/"installed_at":[^,]*/"installed_at":"STRIPPED"/' \
                     -e 's/"updated_at":[^,]*/"updated_at":"STRIPPED"/' \
                     -e 's/"source":[^,]*/"source":"STRIPPED"/' \
-                    "$f" | md5sum | awk '{print $1}'
+                    "$f" | _portable_md5 | awk '{print $1}'
                 ;;
             mcp-config.json|CLAUDE.md|DEVOXXGENIE.md|.devoxxgenie.yaml)
                 # These contain generated paths/content that vary per install dir
@@ -117,10 +117,10 @@ _capture_snapshot() {
                     -e 's|/private/var/[^ ]*|TMPDIR|g' \
                     -e 's|/var/[^ ]*|TMPDIR|g' \
                     -e 's|/tmp/[^ ]*|TMPDIR|g' \
-                    "$f" | md5sum | awk '{print $1}'
+                    "$f" | _portable_md5 | awk '{print $1}'
                 ;;
             *)
-                md5sum "$f" | awk '{print $1}'
+                _portable_md5 "$f" | awk '{print $1}'
                 ;;
         esac
         printf '%s\n' "$f"


### PR DESCRIPTION
## Summary

Fixes three test reliability bugs:

- **#246 (P1)**: Replace `echo|grep -q` pipes with herestrings (`<<<`) in all assertion functions to eliminate SIGPIPE race under `set -o pipefail` — affects `assert_contains`, `assert_not_contains`, `assert_matches`, `assert_hook_denies`, `assert_hook_allows`, `assert_hook_asks`
- **#247 (P2)**: Add `_portable_md5` (`md5sum` → `md5 -r` fallback) and `_portable_timeout` (`timeout` → `gtimeout` → `perl` fallback) wrappers to `test-helpers.sh`; update suites 12, 14, 21
- **#248 (P3)**: Remove external file validation from suite 16 that depended on `dev-notes/` content outside the repo

Also recaptures `claude.snapshot` baseline after PR #251 changed `settings.json`.

Closes #246
Closes #247
Closes #248

## Test plan

- [x] 21/21 suites pass (1186 assertions, 0 failures)
- [x] ShellCheck clean on all modified files
- [x] Snapshot baselines recaptured and verified
- [x] Peer-reviewed: W1 (assert_hook_* pipes) fixed, W2 (unreachable _skip path) accepted