### PR TITLE
fix(skills, cicd): skill-sync preamble parsing + project-board workflow guards

### DIFF
--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -92,7 +92,10 @@ jobs:
                   fieldId: "'"$STATUS_FIELD_ID"'"
                   value: { singleSelectOptionId: "'"$IN_PROGRESS_ID"'" }
                 }) { projectV2Item { id } }
-              }'
+              }' || {
+                echo "::warning::Board mutation failed for #$ISSUE_NUM (check PROJECT_PAT scopes or project permissions)"
+                continue
+              }
               echo "Moved #$ISSUE_NUM: Todo → In Progress"
             else
               echo "Issue #$ISSUE_NUM in '$CURRENT', not moving (only Todo → In Progress)"
@@ -146,7 +149,10 @@ jobs:
                 fieldId: "'"$STATUS_FIELD_ID"'"
                 value: { singleSelectOptionId: "'"$DONE_ID"'" }
               }) { projectV2Item { id } }
-            }'
+            }' || {
+              echo "::warning::Board mutation failed for #$ISSUE_NUM (check PROJECT_PAT scopes or project permissions)"
+              continue
+            }
             echo "Moved #$ISSUE_NUM → Done (PR merged)"
           done
 
@@ -186,7 +192,10 @@ jobs:
                 fieldId: "'"$STATUS_FIELD_ID"'"
                 value: { singleSelectOptionId: "'"$TODO_ID"'" }
               }) { projectV2Item { id } }
-            }'
+            }' || {
+              echo "::warning::Board mutation failed for #$ISSUE_NUM (check PROJECT_PAT scopes or project permissions)"
+              exit 0
+            }
             echo "Moved #$ISSUE_NUM: $CURRENT → Todo (assigned)"
           else
             echo "Issue #$ISSUE_NUM in '$CURRENT', not moving"
@@ -215,7 +224,10 @@ jobs:
               projectId: "'"$PROJECT_ID"'"
               contentId: "'"$ISSUE_NODE_ID"'"
             }) { item { id } }
-          }' --jq '.data.addProjectV2ItemById.item.id')
+          }' --jq '.data.addProjectV2ItemById.item.id') || {
+            echo "::warning::Board mutation failed for #$ISSUE_NUM (check PROJECT_PAT scopes — org-owned projects need read:org)"
+            exit 0
+          }
 
           if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then
             gh api graphql -f query='mutation {
@@ -225,7 +237,10 @@ jobs:
                 fieldId: "'"$STATUS_FIELD_ID"'"
                 value: { singleSelectOptionId: "'"$BACKLOG_ID"'" }
               }) { projectV2Item { id } }
-            }'
+            }' || {
+              echo "::warning::Issue #$ISSUE_NUM added to board but could not set Backlog status"
+              exit 0
+            }
             echo "Added #$ISSUE_NUM to board → Backlog"
           fi
 
@@ -265,7 +280,10 @@ jobs:
                 fieldId: "'"$STATUS_FIELD_ID"'"
                 value: { singleSelectOptionId: "'"$IN_PROGRESS_ID"'" }
               }) { projectV2Item { id } }
-            }'
+            }' || {
+              echo "::warning::Board mutation failed for #$ISSUE_NUM (check PROJECT_PAT scopes or project permissions)"
+              exit 0
+            }
             echo "Moved #$ISSUE_NUM: $CURRENT → In Progress (reopened)"
           fi
 
@@ -329,7 +347,10 @@ jobs:
               fieldId: "'"$STATUS_FIELD_ID"'"
               value: { singleSelectOptionId: "'"$DONE_ID"'" }
             }) { projectV2Item { id } }
-          }'
+          }' || {
+            echo "::warning::Board mutation failed for #$ISSUE_NUM (check PROJECT_PAT scopes or project permissions)"
+            exit 0
+          }
           echo "Moved #$ISSUE_NUM → Done (closed, criteria verified)"
 
   # ── Weekly reconciliation — catch any closed issues with stale board status ──
@@ -369,7 +390,10 @@ jobs:
                     fieldId: "'"$STATUS_FIELD_ID"'"
                     value: { singleSelectOptionId: "'"$DONE_ID"'" }
                   }) { projectV2Item { id } }
-                }' --silent
+                }' --silent || {
+                  echo "::warning::Board mutation failed for #$NUM (check PROJECT_PAT scopes or project permissions)"
+                  continue
+                }
                 echo "Reconciled #$NUM → Done (was closed but board status stale)"
                 FIXED=$((FIXED + 1))
               fi

--- a/core/skills/skill-sync/SKILL.md
+++ b/core/skills/skill-sync/SKILL.md
@@ -22,7 +22,7 @@ Manages the synchronization of cognitive-core components (agents, skills, hooks)
 !`cat .claude/cognitive-core/version.json 2>/dev/null | head -20 || echo "ERROR: No version.json found. Run install.sh first."`
 
 ### Framework Source
-!`SOURCE=$(cat .claude/cognitive-core/version.json 2>/dev/null | grep '"source"' | sed 's/.*"source"[[:space:]]*:[[:space:]]*"//;s/".*//' ); if [ -d "$SOURCE" ]; then echo "Framework: $SOURCE"; git -C "$SOURCE" log --oneline -3 2>/dev/null; else echo "ERROR: Framework source not found at $SOURCE"; fi`
+!`VF=.claude/cognitive-core/version.json; if command -v jq >/dev/null 2>&1; then SOURCE=$(jq -r '.source // ""' "$VF" 2>/dev/null); else SOURCE=$(grep -o '"source"[[:space:]]*:[[:space:]]*"[^"]*"' "$VF" 2>/dev/null | head -1 | sed 's/.*"source"[[:space:]]*:[[:space:]]*"//;s/"//'); fi; if [ -n "$SOURCE" ] && [ -d "$SOURCE" ]; then echo "Framework: $SOURCE"; git -C "$SOURCE" log --oneline -3 2>/dev/null || true; else echo "ERROR: Framework source not found at ${SOURCE:-<empty>}"; fi`
 
 ### Installed Components
 !`echo "=== Agents ==="; ls -1 .claude/agents/*.md 2>/dev/null | xargs -I{} basename {} .md; echo "=== Skills ==="; ls -d .claude/skills/*/SKILL.md 2>/dev/null | sed 's|.claude/skills/||;s|/SKILL.md||'; echo "=== Hooks ==="; ls -1 .claude/hooks/*.sh 2>/dev/null | xargs -I{} basename {} .sh`
@@ -88,7 +88,12 @@ If `--auto` flag: suppress interactive output, only report errors/conflicts.
 
 Execute update using the framework's updater:
 ```bash
-SOURCE=$(cat .claude/cognitive-core/version.json 2>/dev/null | grep '"source"' | sed 's/.*"source"[[:space:]]*:[[:space:]]*"//;s/".*//');
+VF=.claude/cognitive-core/version.json
+if command -v jq >/dev/null 2>&1; then
+    SOURCE=$(jq -r '.source // ""' "$VF" 2>/dev/null)
+else
+    SOURCE=$(grep -o '"source"[[:space:]]*:[[:space:]]*"[^"]*"' "$VF" 2>/dev/null | head -1 | sed 's/.*"source"[[:space:]]*:[[:space:]]*"//;s/"//')
+fi
 # Pull latest framework source first
 git -C "$SOURCE" pull origin main --quiet 2>/dev/null || true
 # Run the checksum-based updater
@@ -100,7 +105,12 @@ git -C "$SOURCE" pull origin main --quiet 2>/dev/null || true
 Install a component from the framework that isn't currently installed:
 
 ```bash
-SOURCE=$(cat .claude/cognitive-core/version.json 2>/dev/null | grep '"source"' | sed 's/.*"source"[[:space:]]*:[[:space:]]*"//;s/".*//');
+VF=.claude/cognitive-core/version.json
+if command -v jq >/dev/null 2>&1; then
+    SOURCE=$(jq -r '.source // ""' "$VF" 2>/dev/null)
+else
+    SOURCE=$(grep -o '"source"[[:space:]]*:[[:space:]]*"[^"]*"' "$VF" 2>/dev/null | head -1 | sed 's/.*"source"[[:space:]]*:[[:space:]]*"//;s/"//')
+fi
 ```
 
 - **Agent**: `cp "$SOURCE/core/agents/<name>.md" .claude/agents/`

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -41,6 +41,9 @@ suite_pretty_name() {
         17-agent-health.sh) echo "Agent Health" ;;
         18-vscode-adapter.sh) echo "VS Code Adapter" ;;
         19-validate-prompt.sh) echo "Validate Prompt" ;;
+        20-smoke-test-abilities.sh) echo "Smoke Test Abilities" ;;
+        21-snapshot-regression.sh) echo "Snapshot Regression" ;;
+        22-skill-sync-preamble.sh) echo "Skill Sync Preamble" ;;
         *) echo "$1" ;;
     esac
 }

--- a/tests/suites/22-skill-sync-preamble.sh
+++ b/tests/suites/22-skill-sync-preamble.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Test suite: skill-sync preamble parsing
+# Regression guard for #255 — brittle grep|sed JSON parsing + unguarded git log exit
+# in core/skills/skill-sync/SKILL.md caused /skill-sync to fail on session start.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../lib/test-helpers.sh"
+
+suite_start "22 — Skill Sync Preamble"
+
+SKILL_FILE="${ROOT_DIR}/core/skills/skill-sync/SKILL.md"
+
+# =============================================================================
+# Section 1: Static content guards — non-regression against the buggy pattern
+# =============================================================================
+
+assert_file_exists "skill-sync SKILL.md exists" "$SKILL_FILE"
+
+# The buggy pattern `cat ... | grep '"source"' | sed '...;s/".*//'` must not return.
+# Use a distinctive substring that only appears in the old buggy form.
+if grep -qF "s/\".*//" "$SKILL_FILE"; then
+    _fail "non-regression: old sed pattern 's/\".*//' must not appear" \
+          "found buggy sed pattern — should be 's/\"//' in the tighter form"
+else
+    _pass "non-regression: old sed pattern 's/\".*//' removed"
+fi
+
+# The fix should use jq with the conformant `.source // ""` filter
+# (matches core/utilities/check-update.sh:27)
+if grep -qF '.source // ""' "$SKILL_FILE"; then
+    _pass "fix: jq '.source // \"\"' filter present"
+else
+    _fail "fix: jq '.source // \"\"' filter missing" \
+          "expected new parsing pattern not found"
+fi
+
+# The git log must be guarded with `|| true` in the preamble
+if grep -qE 'git -C "\$SOURCE" log --oneline -3 2>/dev/null \|\| true' "$SKILL_FILE"; then
+    _pass "fix: git log guarded with '|| true'"
+else
+    _fail "fix: git log not guarded" \
+          "preamble git log must end with '|| true' to survive non-zero exits"
+fi
+
+# =============================================================================
+# Section 2: Runtime behaviour — extract and execute the preamble block
+# =============================================================================
+
+# The auto-executed preamble is on the line starting with "!`VF=".
+# Extract the single-line shell fragment between the outer backticks.
+extract_preamble() {
+    awk '/^!`VF=/ { sub(/^!`/, ""); sub(/`$/, ""); print; exit }' "$SKILL_FILE"
+}
+
+PREAMBLE=$(extract_preamble)
+
+if [ -z "$PREAMBLE" ]; then
+    _fail "extract: preamble shell fragment found" "could not locate !\`VF=...\` block"
+    suite_end
+    exit $?
+fi
+_pass "extract: preamble shell fragment found"
+
+# Security guard — the suite evaluates the extracted preamble with bash -c.
+# If an attacker modifies SKILL.md to inject shell, refuse to execute.
+# Blocks: network tools, shell escapes, TCP redirects, dynamic eval.
+# Pattern expanded per POSIX ERE (no \b — use word boundaries via surrounding chars).
+if echo "$PREAMBLE" | grep -qE '(^|[^a-zA-Z0-9_-])(curl|wget|nc|netcat|ssh|scp|eval|exec)[[:space:]]|/dev/tcp|/dev/udp|\$\(.*curl|\$\(.*wget|bash[[:space:]]+-i|python[[:space:]]+-c|perl[[:space:]]+-e'; then
+    _fail "security: preamble contains disallowed tokens" \
+          "extracted preamble includes network/eval tokens — refusing to execute"
+    suite_end
+    exit $?
+fi
+_pass "security: preamble passes allowlist guard"
+
+# Helper: run the preamble in an isolated working directory
+# Creates .claude/cognitive-core/version.json from the given JSON body,
+# then executes the extracted preamble snippet. Prints: <exit>|<stdout>
+run_preamble() {
+    local json_body="$1" mock_dir
+    mock_dir=$(create_test_dir)
+    mkdir -p "${mock_dir}/.claude/cognitive-core"
+    if [ -n "$json_body" ]; then
+        printf '%s' "$json_body" > "${mock_dir}/.claude/cognitive-core/version.json"
+    fi
+    local out rc=0
+    out=$(cd "$mock_dir" && bash -c "$PREAMBLE" 2>&1) || rc=$?
+    rm -rf "$mock_dir"
+    printf '%s|%s' "$rc" "$out"
+}
+
+# --- Test: valid version.json pointing at this repo ---
+RESULT=$(run_preamble "$(printf '{"source": "%s", "version": "1.5.0"}' "$ROOT_DIR")")
+RC="${RESULT%%|*}"
+OUT="${RESULT#*|}"
+assert_eq "valid json: exit code is 0" "0" "$RC"
+assert_contains "valid json: outputs 'Framework:' prefix" "$OUT" "Framework:"
+assert_contains "valid json: outputs resolved source path" "$OUT" "$ROOT_DIR"
+
+# --- Test: whitespace variant (extra spaces around colon and value) ---
+RESULT=$(run_preamble "$(printf '{  "source"  :   "%s"  , "version": "1.5.0"}' "$ROOT_DIR")")
+RC="${RESULT%%|*}"
+OUT="${RESULT#*|}"
+assert_eq "whitespace json: exit code is 0" "0" "$RC"
+assert_contains "whitespace json: outputs 'Framework:' prefix" "$OUT" "Framework:"
+
+# --- Test: missing version.json ---
+RESULT=$(run_preamble "")
+RC="${RESULT%%|*}"
+OUT="${RESULT#*|}"
+assert_eq "missing file: exit code is 0" "0" "$RC"
+assert_contains "missing file: outputs ERROR message" "$OUT" "ERROR:"
+
+# --- Test: source key absent from JSON ---
+RESULT=$(run_preamble '{"version": "1.5.0", "installed_at": "2026-01-01"}')
+RC="${RESULT%%|*}"
+OUT="${RESULT#*|}"
+assert_eq "no source key: exit code is 0" "0" "$RC"
+assert_contains "no source key: outputs ERROR message" "$OUT" "ERROR:"
+
+# --- Test: source points to non-existent path ---
+RESULT=$(run_preamble '{"source": "/nonexistent/path/xyzzy", "version": "1.5.0"}')
+RC="${RESULT%%|*}"
+OUT="${RESULT#*|}"
+assert_eq "bad path: exit code is 0" "0" "$RC"
+assert_contains "bad path: outputs ERROR message" "$OUT" "ERROR:"
+
+# --- Test: uninitialized git repo — verifies '|| true' guards git log failure ---
+NONGIT_DIR=$(create_test_dir)
+RESULT=$(run_preamble "$(printf '{"source": "%s", "version": "1.5.0"}' "$NONGIT_DIR")")
+RC="${RESULT%%|*}"
+OUT="${RESULT#*|}"
+assert_eq "non-git source: exit code is 0" "0" "$RC"
+assert_contains "non-git source: outputs 'Framework:' prefix" "$OUT" "Framework:"
+rm -rf "$NONGIT_DIR"
+
+# --- Test: jq-absent fallback path ---
+# Build a shadow PATH containing symlinks to every coreutil EXCEPT jq, so that
+# `command -v jq` fails inside the subshell and the grep|sed branch runs.
+JQ_PATH=$(command -v jq 2>/dev/null || true)
+if [ -n "$JQ_PATH" ]; then
+    SHADOW_DIR=$(create_test_dir)
+    # Symlink every standard binary except jq from /usr/bin and /bin into the shadow.
+    for src_dir in /usr/bin /bin; do
+        [ -d "$src_dir" ] || continue
+        for src_bin in "$src_dir"/*; do
+            [ -x "$src_bin" ] || continue
+            name=$(basename "$src_bin")
+            [ "$name" = "jq" ] && continue
+            [ -e "${SHADOW_DIR}/${name}" ] && continue
+            ln -s "$src_bin" "${SHADOW_DIR}/${name}" 2>/dev/null || true
+        done
+    done
+
+    sanity=$(PATH="$SHADOW_DIR" bash -c 'if command -v jq >/dev/null 2>&1; then echo PRESENT; else echo ABSENT; fi' 2>&1 || true)
+    if [ "$sanity" = "ABSENT" ]; then
+        mock_dir=$(create_test_dir)
+        mkdir -p "${mock_dir}/.claude/cognitive-core"
+        printf '{"source": "%s", "version": "1.5.0"}' "$ROOT_DIR" \
+            > "${mock_dir}/.claude/cognitive-core/version.json"
+
+        rc=0
+        out=$(cd "$mock_dir" && PATH="$SHADOW_DIR" bash -c "$PREAMBLE" 2>&1) || rc=$?
+        assert_eq "jq-absent fallback: exit code is 0" "0" "$rc"
+        assert_contains "jq-absent fallback: outputs 'Framework:' prefix" "$out" "Framework:"
+        assert_contains "jq-absent fallback: outputs resolved source path" "$out" "$ROOT_DIR"
+        rm -rf "$mock_dir"
+    else
+        _skip "jq-absent fallback (could not isolate jq in shadow PATH)"
+    fi
+    rm -rf "$SHADOW_DIR"
+else
+    _skip "jq-absent fallback (jq not installed — cannot verify two-tier parse)"
+fi
+
+suite_end


### PR DESCRIPTION
## Summary

- **Skill-sync preamble fix** (#255): replace brittle `grep`+`sed` JSON parsing with two-tier `jq` with `grep`+`sed` fallback (matches `core/utilities/check-update.sh:27`); add `|| true` guard to `git log` so transient git failures do not kill the preamble exit code. Applied consistently to all 3 `SOURCE=$(...)` blocks in `core/skills/skill-sync/SKILL.md`.
- **Project-board workflow hardening** (follow-up surfaced during #255): add defensive guards to all 7 GraphQL mutation sites in `.github/workflows/project-board-automation.yml`. The `issue-opened` job had no guard at all and caused hard-fail red X on every newly-opened issue when the PAT lacked `read:org` scope. Other jobs relied on pre-checks only — individual mutations could still fail mid-run.

## Peer review

Reviewed across 3 scopes (code-standards, security, test-specialist) — all returned GO. Two blocking findings addressed in this branch:
- **Conformance (R1)**: `.source // empty` → `.source // ""` to exactly match the `check-update.sh:27` reference pattern
- **Security (S4)**: added allowlist guard in `tests/suites/22-skill-sync-preamble.sh` that refuses to evaluate the extracted preamble if it contains network or eval tokens (`wget`, `nc`, `ssh`, `eval`, `/dev/tcp`, `bash -i`, etc.) — belt-and-suspenders against fork-PR RCE if suite 22 is ever added to the `ci.yml` fork-PR test matrix

## Not closed by this PR

- #256 (P1 security) — `$SOURCE/update.sh` executed without path validation — scoped out intentionally as it requires a broader design (realpath containment + exec-owner check). Stays open.

## Test plan

- [x] `bash tests/suites/22-skill-sync-preamble.sh` — 22 passed, 0 failed, 0 skipped
- [x] Manual smoke test against live `version.json`: `Framework: /Users/pewo/workspace/cognitive-core` + 3 git log lines, exit 0
- [x] `PROJECT_PAT` rotated with `read:org`, workflow now `success` (run #24583797904) and test issue #258 correctly added to board → Backlog and moved → Done
- [x] Verified allowlist guard blocks malicious preamble: network-fetch-plus-eval sample → BLOCKED
- [x] Acceptance criteria verification: 7/7 PASS per test-specialist report (BOM + spaces-in-path edge cases work in practice, not asserted — low risk)

Closes #255