### PR TITLE
fix(cicd): guard closure-guard grep pattern with -- (#262)

### DIFF
--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -308,9 +308,11 @@ jobs:
 
           ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --repo "$GH_REPO" --json body --jq '.body // ""')
 
-          # Check if issue has acceptance criteria (checkbox patterns)
+          # Check if issue has acceptance criteria (checkbox patterns).
+          # `--` required: pattern starts with `-`, which grep would otherwise parse as an option
+          # and exit 2. Prior bug silently bypassed the approval gate (#262).
           HAS_CRITERIA="false"
-          if echo "$ISSUE_BODY" | grep -qE '- \[ \]|- \[x\]'; then
+          if echo "$ISSUE_BODY" | grep -qE -- '- \[ \]|- \[x\]'; then
             HAS_CRITERIA="true"
           fi
 


### PR DESCRIPTION
## Summary

One-line fix to restore the approval gate. The closure-guard pattern `- \[ \]|- \[x\]` starts with a literal `-`, which GNU grep on Ubuntu parses as an option flag (exit 2, `grep: invalid option -- ' '`). The surrounding `if` evaluates false, `HAS_CRITERIA` stays `"false"`, and the acceptance-criteria + approved-label guard never fires. Every merged PR that closes an issue with acceptance criteria flows straight to Done, skipping **To Be Tested**.

Add `--` before the pattern so grep treats the following argument as pattern, not option.

## Reproduction

Observed on mindcockpit-ai/cognitive-core#260 closure (2026-04-18T18:11:11Z):

- CI log: `grep: invalid option -- ' '` → `Moved #260 → Done (closed, criteria verified)`
- Acceptance criteria ticked, `approved` label absent, issue moved straight to Done.

Local:
```
$ echo "- [x]" | grep -qE '- \[ \]|- \[x\]'; echo rc=$?
grep: invalid option --
rc=2

$ echo "- [x]" | grep -qE -- '- \[ \]|- \[x\]'; echo rc=$?
rc=0
```

## Acceptance criteria

- [x] `.github/workflows/project-board-automation.yml` grep uses `--` so leading `-` in pattern does not parse as option
- [x] Audit of other workflow grep calls in `.github/workflows/*` — no other pattern argument begins with `-` unguarded (verified: only the closure-guard line had the bug)
- [ ] Manual verification (next merge of a PR closing an issue with acceptance criteria): issue moves to **To Be Tested**, not Done, when `approved` label is absent. To be confirmed on first post-merge closure event.
- [ ] Reproduction test in a regression suite. (Deferred — `project-board-automation.yml` runs only on GitHub events and has no offline test harness today. Worth tracking as a follow-up.)

## Out of scope

- Framework template `cicd/workflows/project-board-automation.yml` — already uses different, correct approval-gate logic.
- Retroactively re-opening mindcockpit-ai/cognitive-core#260. Work is independently verified; merge was explicit.

## Test plan

- [x] Local repro shows `rc=2` before and `rc=0` after the fix.
- [x] Audit grep in `.github/workflows/*` — no other leading-`-` pattern arguments.
- [ ] Observed on next closing PR merge: approval-gate-respecting path actually triggers.

Closes mindcockpit-ai/cognitive-core#262