### PR TITLE
fix(cicd): closure-guard routes reopened issue to To Be Tested (#262)

### DIFF
--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -317,11 +317,35 @@ jobs:
           fi
 
           if [ "$APPROVED" -eq 0 ] && [ "$HAS_CRITERIA" = "true" ]; then
-            echo "Issue #$ISSUE_NUM has acceptance criteria but no 'approved' label — reopening"
+            echo "Issue #$ISSUE_NUM has acceptance criteria but no 'approved' label — routing to To Be Tested"
+            # Move to "To Be Tested" on the board BEFORE reopening. The issue-reopened
+            # job only routes Done/Canceled → In Progress, so it will leave TBT alone.
+            # Without this, pr-merged can miss the link (cross-repo `owner/repo#N` form)
+            # and the issue ends up in In Progress instead of parked for review (#262).
+            GUARD_ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 2>&1 | tr -d '\000-\037') || {
+              echo "::warning::Cannot access project board — skipping TBT routing for #$ISSUE_NUM"
+              GUARD_ITEMS=""
+            }
+            if [ -n "$GUARD_ITEMS" ]; then
+              GUARD_ITEM_ID=$(echo "$GUARD_ITEMS" | jq -r --argjson n "$ISSUE_NUM" \
+                '.items[] | select(.content.number == $n) | .id')
+              if [ -n "$GUARD_ITEM_ID" ] && [ "$GUARD_ITEM_ID" != "null" ]; then
+                gh api graphql -f query='mutation {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: "'"$PROJECT_ID"'"
+                    itemId: "'"$GUARD_ITEM_ID"'"
+                    fieldId: "'"$STATUS_FIELD_ID"'"
+                    value: { singleSelectOptionId: "'"$TESTING_ID"'" }
+                  }) { projectV2Item { id } }
+                }' || {
+                  echo "::warning::Board mutation failed for #$ISSUE_NUM — continuing with reopen"
+                }
+              fi
+            fi
             gh issue reopen "$ISSUE_NUM" --repo "$GH_REPO"
             GUARD_MSG="**Closure guard (CI)**: This issue was closed without the \`approved\` label."
             GUARD_MSG="$GUARD_MSG"$'\n\n'"The issue body contains acceptance criteria checkboxes, but no \`approved\` label was found."
-            GUARD_MSG="$GUARD_MSG"$'\n\n'"Please verify all acceptance criteria and close via \`/project-board close\` or"
+            GUARD_MSG="$GUARD_MSG"$'\n\n'"Moved to **To Be Tested** on the board. Please verify all acceptance criteria and close via \`/project-board approve\` or"
             GUARD_MSG="$GUARD_MSG"$'\n'"add the \`approved\` label before closing."
             gh issue comment "$ISSUE_NUM" --repo "$GH_REPO" --body "$GUARD_MSG"
             exit 0


### PR DESCRIPTION
## Summary

Completes #262 by finishing the last acceptance criterion — when the closure-guard fires, the issue should end up parked in **To Be Tested** awaiting human approval, not in In Progress.

## Root cause

Two independent paths could land the issue in TBT:

1. **`pr-merged` links issues** — extracts `Closes #N` from the PR body via `grep -oiE '(close[sd]?|...)\s+#[0-9]+'`. This regex rejects cross-repo forms like `Closes owner/repo#N`. When the PR body uses the cross-repo form, pr-merged finds no links and doesn't move the issue.
2. **`issue-closed` closure-guard** — after the grep fix in #263, the guard correctly reopens the issue but relied on pr-merged having already set TBT. When pr-merged missed the link, the guard exited without setting a board status, and `issue-reopened` left the issue in its current column (In Progress).

Result on #262: the guard fired, the issue reopened, but final board state was In Progress, not TBT.

## Fix

Move the explicit `updateProjectV2ItemFieldValue → TESTING_ID` into the closure-guard branch, before `gh issue reopen`. `issue-reopened` only touches Done/Canceled → In Progress, so TBT is preserved.

## Acceptance verification (tests itself on merge)

This PR's merge will:
1. Close #262 (via `Closes #262` in the body — bare form so pr-merged's regex catches it).
2. `pr-merged` sees `#262`, moves it to TBT.
3. `issue-closed` fires: `approved` label absent + has criteria → guard branch → explicit TBT move (no-op now, safe) → reopen + comment.
4. `issue-reopened` sees `CURRENT = To Be Tested` → leaves alone.

Expected final state: #262 **OPEN**, status **To Be Tested**, awaiting `/project-board approve`.

## Test plan

- [x] YAML syntax sane (`grep -q` parsing confirms structure).
- [ ] Live self-test: observe #262's post-merge state on the board. Expected: OPEN + TBT.
- [ ] `pr-merged` cross-repo regex gap is a separate concern (tracked in a follow-up if needed — widening the regex to accept `owner/repo#N` is backwards-compatible).

Closes #262