### PR TITLE
fix(install): anchor state-dir matchers + add lint guard (#265)

### DIFF
--- a/core/skills/project-board/validate-prompt.sh
+++ b/core/skills/project-board/validate-prompt.sh
@@ -61,7 +61,13 @@ INPUT_CLEAN=$(printf '%s' "$INPUT_CLEAN" | LC_ALL=C sed \
     -e 's/\xEF\xBB\xBF//g' 2>/dev/null) || true
 
 # Homoglyph normalisation (Cyrillic/Greek confusables → ASCII)
-INPUT_CLEAN=$(printf '%s' "$INPUT_CLEAN" | iconv -f UTF-8 -t ASCII//TRANSLIT//IGNORE 2>/dev/null || printf '%s' "$INPUT_CLEAN")
+# macOS iconv exits non-zero when any char is transliterated/ignored even with
+# valid output, so the previous `|| printf` fallback appended the original input
+# and doubled the buffer on em-dash-bearing prompts. Capture into a temp var and
+# accept it only when non-empty.
+_iconv_out=$(printf '%s' "$INPUT_CLEAN" | iconv -f UTF-8 -t ASCII//TRANSLIT//IGNORE 2>/dev/null || true)
+[ -n "$_iconv_out" ] && INPUT_CLEAN="$_iconv_out"
+unset _iconv_out
 
 # Save full text for structural checks
 FULL_TEXT="$INPUT_CLEAN"

--- a/install.sh
+++ b/install.sh
@@ -845,7 +845,7 @@ mkdir -p "$MANIFEST_DIR"
 INSTALLED_FILES="[]"
 if command -v python3 &>/dev/null; then
     # Use python for proper JSON array construction
-    INSTALLED_FILES=$(find "${CC_INSTALL_DIR}" -type f -not -path "*/cognitive-core/*" | sort | python3 -c "
+    INSTALLED_FILES=$(find "${CC_INSTALL_DIR}" -type f -not -path "${CC_INSTALL_DIR}/cognitive-core/*" | sort | python3 -c "
 import sys, json, hashlib, os
 files = []
 project = '${PROJECT_DIR}'

--- a/tests/suites/19-validate-prompt.sh
+++ b/tests/suites/19-validate-prompt.sh
@@ -431,4 +431,42 @@ rm -rf "$_SIBLING"
 # Cleanup fixture
 rm -rf "$L2_FIXTURE"
 
+# =============================================================================
+# Section 5: iconv TRANSLIT fallback regression (#265 secondary finding)
+# =============================================================================
+# macOS iconv exits non-zero whenever any character is transliterated or
+# ignored, even with valid output. The previous fallback
+#   INPUT_CLEAN=$(... iconv ... || printf '%s' "$INPUT_CLEAN")
+# appended the original input, doubling the buffer for any prompt containing
+# an em-dash (or any non-ASCII glyph). Downstream word counts would read as
+# twice the true length.
+#
+# Regression: feed a prompt whose true instruction-section word count is
+# >200 and <=400 with an embedded em-dash. Bug-doubled buffer lands >400,
+# triggering the S1 structure warning. Fixed buffer stays under the limit.
+
+# Build ~270 instruction words with one em-dash. Stays <400 normally; doubled
+# to ~540 it would trip the "exceeds 400 limit" warning.
+_IC_SCOPE_WORDS=""
+for _i in $(seq 1 54); do
+    _IC_SCOPE_WORDS="${_IC_SCOPE_WORDS} alpha beta gamma delta epsilon"
+done
+
+# Insert one em-dash (UTF-8 E2 80 94) so iconv actually transliterates.
+ICONV_PROMPT=$(printf '<scope>\nimplement core/auth/handler.sh \xe2\x80\x94 %s\n</scope>\n<constraints>\nDo NOT skip tests\n</constraints>' "$_IC_SCOPE_WORDS")
+
+iconv_out=$(printf '%s' "$ICONV_PROMPT" | bash "$VP_SCRIPT" 2>/dev/null) || true
+assert_not_contains "iconv fix: word count not doubled (no 'exceeds 400' warning)" "$iconv_out" "exceeds 400"
+
+# Also assert the linter still completes normally (clean structural output).
+assert_contains "iconv fix: linter runs to completion on em-dash prompt" "$iconv_out" "Disclaimer"
+
+# Static guard: the buggy `|| printf` fallback pattern must not return.
+if grep -qE '\| iconv [^|]*\|\| printf' "$VP_SCRIPT"; then
+    _fail "iconv fix: buggy '|| printf' fallback still present in validate-prompt.sh" \
+          "capture-into-temp pattern required; see #265 secondary finding"
+else
+    _pass "iconv fix: buggy '|| printf' fallback removed from validate-prompt.sh"
+fi
+
 suite_end

--- a/tests/suites/25-anchored-state-references.sh
+++ b/tests/suites/25-anchored-state-references.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+# Test suite 25 — Anchored State References (#265)
+#
+# Regression + structural invariant for the manifest-regeneration bug where
+# `find ... -not -path "*/cognitive-core/*"` excluded every file whenever the
+# project path contained the substring `cognitive-core`. Fixed by anchoring
+# the exclusion to ${CLAUDE_DIR}/cognitive-core/* (update.sh) and
+# ${CC_INSTALL_DIR}/cognitive-core/* (install.sh).
+#
+# Section 1: Lint scan — fails if any path-filter flag is followed by the
+#            unanchored glob `*/cognitive-core/*`. Converts the one-off fix
+#            into a structural invariant.
+# Section 2: Self-host runtime fixture — installs into a tempdir whose name
+#            literally contains `cognitive-core` (the substring that triggers
+#            the original bug) and asserts the regenerated manifest is
+#            non-empty and contains known-present hook entries.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SUITE_SELF_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../lib/test-helpers.sh"
+
+suite_start "25 — Anchored State References"
+
+# =============================================================================
+# Section 1: Lint scan — no unanchored `*/cognitive-core/*` in path-filter flags
+# =============================================================================
+# Pattern: one of the path-filter flags (-path, -not -path, -iname, --include,
+# --exclude) followed by an optional opening quote and then the unanchored glob.
+# Excludes this suite's own file so the regex literal in the comment above does
+# not self-flag the scan.
+
+LINT_REGEX='(-path|-not[[:space:]]+-path|-iname|--include|--exclude)[[:space:]]+["'\'']?\*/cognitive-core/\*'
+
+# Enumerate tracked files via git ls-files (run from ROOT_DIR for correct paths).
+# Exclude the suite file itself so the regex literal above does not trigger.
+mapfile -t LINT_HITS < <(
+    cd "$ROOT_DIR" && git ls-files -z 2>/dev/null \
+        | xargs -0 grep -HnE "$LINT_REGEX" 2>/dev/null \
+        | grep -vE "^tests/suites/${SUITE_SELF_NAME}(:|$)" \
+        || true
+)
+
+if [ "${#LINT_HITS[@]}" -eq 0 ]; then
+    _pass "lint: no unanchored '*/cognitive-core/*' path-filter matches found"
+else
+    _fail "lint: unanchored '*/cognitive-core/*' path-filter matches found" \
+          "$(printf '%s\n' "${LINT_HITS[@]}")"
+fi
+
+# =============================================================================
+# Section 2: Self-host fixture — install + update into a cognitive-core-named
+# project and assert the manifest is populated.
+# =============================================================================
+# The tempdir name MUST contain `cognitive-core` — that substring is exactly
+# what triggered the original unanchored-glob bug (see issue #265).
+
+if ! command -v python3 >/dev/null 2>&1; then
+    _skip "self-host fixture: python3 not available"
+    suite_end
+    exit $?
+fi
+
+# mktemp -d -t on macOS yields /var/folders/.../cognitive-core-test.XXXX.SUFFIX
+# On Linux it yields /tmp/cognitive-core-test.XXXX.SUFFIX. Both paths contain
+# the trigger substring.
+FIXTURE_DIR=$(mktemp -d -t cognitive-core-test.XXXX) || FIXTURE_DIR=""
+if [ -z "$FIXTURE_DIR" ] || [ ! -d "$FIXTURE_DIR" ]; then
+    _skip "self-host fixture: mktemp failed to create cognitive-core-named dir"
+    suite_end
+    exit $?
+fi
+
+cleanup() {
+    [ -n "${FIXTURE_DIR:-}" ] && [ -d "${FIXTURE_DIR}" ] && rm -rf "${FIXTURE_DIR}"
+}
+trap cleanup EXIT
+
+# Confirm the substring is present — if the platform's mktemp stripped the
+# template prefix the fixture is not meaningful.
+case "$FIXTURE_DIR" in
+    *cognitive-core*) _pass "self-host fixture: tempdir contains 'cognitive-core' trigger substring" ;;
+    *)
+        _fail "self-host fixture: tempdir missing 'cognitive-core' substring" \
+              "got: ${FIXTURE_DIR}"
+        suite_end
+        exit $?
+        ;;
+esac
+
+# Initialize a minimal git repo (install.sh requires this).
+git -C "$FIXTURE_DIR" init --quiet 2>/dev/null
+
+# Seed a conf so install.sh takes the non-interactive branch (same pattern as
+# suite 04). Keep CC_HOOKS set to a subset we assert on later.
+cat > "${FIXTURE_DIR}/cognitive-core.conf" <<'EOF'
+#!/bin/false
+CC_PROJECT_NAME="cognitive-core-test"
+CC_PROJECT_DESCRIPTION="Self-host fixture for #265"
+CC_ORG="test-org"
+CC_LANGUAGE="python"
+CC_LINT_EXTENSIONS=".py"
+CC_LINT_COMMAND="ruff check $1"
+CC_FORMAT_COMMAND=""
+CC_TEST_COMMAND="pytest"
+CC_TEST_PATTERN="tests/**/*.py"
+CC_DATABASE="none"
+CC_ARCHITECTURE="ddd"
+CC_SRC_ROOT="src"
+CC_TEST_ROOT="tests"
+CC_AGENTS="coordinator reviewer researcher"
+CC_COORDINATOR_MODEL="opus"
+CC_SPECIALIST_MODEL="sonnet"
+CC_SKILLS="session-resume code-review security-baseline"
+CC_HOOKS="setup-env compact-reminder validate-bash validate-read validate-fetch validate-write post-edit-lint"
+CC_MAIN_BRANCH="main"
+CC_COMMIT_FORMAT="conventional"
+CC_COMMIT_SCOPES="api core"
+CC_ENABLE_CICD="false"
+CC_RUNNER_TYPE="github-hosted"
+CC_MONITORING="false"
+CC_SECURITY_LEVEL="standard"
+CC_BLOCKED_PATTERNS=""
+CC_ALLOWED_DOMAINS=""
+CC_KNOWN_SAFE_DOMAINS=""
+CC_COMPACT_RULES="1. Follow standards"
+CC_ENABLE_CLEANUP_CRON="false"
+CC_SESSION_DOCS_DIR="docs"
+CC_SESSION_MAX_AGE_DAYS="30"
+CC_FITNESS_LINT="60"
+CC_FITNESS_COMMIT="80"
+CC_FITNESS_TEST="85"
+CC_FITNESS_MERGE="90"
+CC_FITNESS_DEPLOY="95"
+CC_RUNNER_NODES="1"
+CC_RUNNER_LABELS="self-hosted"
+CC_AGENT_TEAMS="false"
+CC_MCP_SERVERS=""
+EOF
+
+# Run install.sh
+install_out=$(bash "${ROOT_DIR}/install.sh" "$FIXTURE_DIR" 2>&1) || {
+    _fail "self-host fixture: install.sh failed" "$(printf '%s\n' "$install_out" | tail -20)"
+    suite_end
+    exit $?
+}
+_pass "self-host fixture: install.sh completed"
+
+# Assertion: install-produced manifest is non-empty and contains expected hooks.
+INSTALL_MANIFEST="${FIXTURE_DIR}/.claude/cognitive-core/version.json"
+if [ ! -f "$INSTALL_MANIFEST" ]; then
+    _fail "self-host fixture: install manifest missing" "expected at ${INSTALL_MANIFEST}"
+    suite_end
+    exit $?
+fi
+_pass "self-host fixture: install manifest exists"
+
+install_count=$(python3 -c "
+import json, sys
+try:
+    with open('${INSTALL_MANIFEST}') as f:
+        data = json.load(f)
+    print(len(data.get('files', [])))
+except Exception as exc:
+    print('ERR:%s' % exc)
+    sys.exit(1)
+" 2>&1)
+
+case "$install_count" in
+    ERR:*|'')
+        _fail "self-host fixture: install manifest JSON unreadable" "$install_count"
+        ;;
+    0)
+        _fail "self-host fixture: install manifest is empty (#265 regression)" \
+              "files[] length is 0; expected > 0 in cognitive-core-named tempdir"
+        ;;
+    *)
+        if [ "$install_count" -gt 0 ] 2>/dev/null; then
+            _pass "self-host fixture: install manifest non-empty (${install_count} entries)"
+        else
+            _fail "self-host fixture: install manifest count not numeric" "got: ${install_count}"
+        fi
+        ;;
+esac
+
+# Assert specific hook paths are present (fail-soft deterministic markers).
+install_paths_check=$(python3 -c "
+import json
+with open('${INSTALL_MANIFEST}') as f:
+    data = json.load(f)
+paths = {e.get('path', '') for e in data.get('files', [])}
+need = ['.claude/hooks/setup-env.sh', '.claude/hooks/validate-bash.sh']
+missing = [p for p in need if p not in paths]
+print('OK' if not missing else 'MISSING:' + ','.join(missing))
+" 2>&1)
+
+if [ "$install_paths_check" = "OK" ]; then
+    _pass "self-host fixture: install manifest contains setup-env.sh + validate-bash.sh"
+else
+    _fail "self-host fixture: install manifest missing expected hooks" "$install_paths_check"
+fi
+
+# ---- Now run update.sh over the fixture ----
+# Disable branch-guard auto-switching: the fixture has no origin remote, so the
+# guard is already skipped, but set it explicitly for safety across envs.
+CC_SYNC_ENFORCE=false update_out=$(CC_SYNC_ENFORCE=false bash "${ROOT_DIR}/update.sh" "$FIXTURE_DIR" 2>&1) || {
+    _fail "self-host fixture: update.sh failed" "$(printf '%s\n' "$update_out" | tail -20)"
+    suite_end
+    exit $?
+}
+_pass "self-host fixture: update.sh completed"
+
+update_count=$(python3 -c "
+import json
+with open('${INSTALL_MANIFEST}') as f:
+    data = json.load(f)
+print(len(data.get('files', [])))
+" 2>&1)
+
+case "$update_count" in
+    0)
+        _fail "self-host fixture: update manifest is empty (#265 regression)" \
+              "update.sh regenerated an empty manifest in cognitive-core-named project"
+        ;;
+    *)
+        if [ "$update_count" -gt 0 ] 2>/dev/null; then
+            _pass "self-host fixture: update manifest non-empty (${update_count} entries)"
+        else
+            _fail "self-host fixture: update manifest count not numeric" "got: ${update_count}"
+        fi
+        ;;
+esac
+
+update_paths_check=$(python3 -c "
+import json
+with open('${INSTALL_MANIFEST}') as f:
+    data = json.load(f)
+paths = {e.get('path', '') for e in data.get('files', [])}
+need = ['.claude/hooks/setup-env.sh', '.claude/hooks/validate-bash.sh']
+missing = [p for p in need if p not in paths]
+print('OK' if not missing else 'MISSING:' + ','.join(missing))
+" 2>&1)
+
+if [ "$update_paths_check" = "OK" ]; then
+    _pass "self-host fixture: update manifest contains setup-env.sh + validate-bash.sh"
+else
+    _fail "self-host fixture: update manifest missing expected hooks" "$update_paths_check"
+fi
+
+suite_end

--- a/tests/suites/25-anchored-state-references.sh
+++ b/tests/suites/25-anchored-state-references.sh
@@ -207,7 +207,7 @@ fi
 # ---- Now run update.sh over the fixture ----
 # Disable branch-guard auto-switching: the fixture has no origin remote, so the
 # guard is already skipped, but set it explicitly for safety across envs.
-CC_SYNC_ENFORCE=false update_out=$(CC_SYNC_ENFORCE=false bash "${ROOT_DIR}/update.sh" "$FIXTURE_DIR" 2>&1) || {
+update_out=$(CC_SYNC_ENFORCE=false bash "${ROOT_DIR}/update.sh" "$FIXTURE_DIR" 2>&1) || {
     _fail "self-host fixture: update.sh failed" "$(printf '%s\n' "$update_out" | tail -20)"
     suite_end
     exit $?

--- a/update.sh
+++ b/update.sh
@@ -332,7 +332,7 @@ header "Updating version manifest"
 # Regenerate file checksums
 INSTALLED_FILES="[]"
 if command -v python3 &>/dev/null; then
-    INSTALLED_FILES=$(find "${CLAUDE_DIR}" -type f -not -path "*/cognitive-core/*" | sort | python3 -c "
+    INSTALLED_FILES=$(find "${CLAUDE_DIR}" -type f -not -path "${CLAUDE_DIR}/cognitive-core/*" | sort | python3 -c "
 import sys, json, hashlib, os
 files = []
 project = '${PROJECT_DIR}'


### PR DESCRIPTION
## Summary

Fixes the unanchored `*/cognitive-core/*` glob that made `update.sh` regenerate an empty `version.json` manifest whenever the project path contained the substring `cognitive-core` (most notably when dogfooded). Applies the same anchor fix at the matching `install.sh` site, which also silently impacted the aider, intellij, and vscode adapters (their `CC_INSTALL_DIR` is `.cognitive-core`). Folds in the peer-reviewed secondary finding — `validate-prompt.sh`'s iconv TRANSLIT fallback was doubling input on macOS whenever a prompt contained a transliterable character such as an em-dash.

Implements **Option A** from the issue's peer-reviewed strategy section: anchor the matchers + add a lint suite that converts the one-off fix into a structural invariant. Options B (sentinel helper) and C (rename state directory) were considered and explicitly rejected in the issue body with a cost/benefit table.

## Changes

- `update.sh:335` — anchor to `${CLAUDE_DIR}/cognitive-core/*`
- `install.sh:848` — anchor to `${CC_INSTALL_DIR}/cognitive-core/*`
- `core/skills/project-board/validate-prompt.sh:64` — capture-into-temp pattern replaces the `|| printf '%s' "$INPUT_CLEAN"` fallback that doubled the buffer on macOS iconv non-zero exits
- `tests/suites/25-anchored-state-references.sh` — new suite (9 tests)
  - Section 1: lint scanner fails on any unanchored `*/cognitive-core/*` path-filter occurrence (structural invariant)
  - Section 2: self-host fixture using `mktemp -d -t cognitive-core-test.XXXX` (trigger substring guaranteed), runs `install.sh` + `update.sh`, asserts manifests are non-empty and contain known hook entries
- `tests/suites/19-validate-prompt.sh` — extended with 3 iconv regression tests (270-word em-dash prompt stays under the 400-word structural warning, linter completes, buggy `|| printf` static guard)

Refs #265.

## Strategy

Adopts **Option A** from the issue's peer-reviewed strategy section. The root cause is unanchored glob patterns, not the state-directory name — renaming (Option C) would re-introduce the same class for any project path containing the new name. Anchored matching plus a lint invariant is the structural fix.

## Test plan

- [x] `bash tests/run-all.sh` — all 24 suites pass (23 previously existing + new suite 25)
- [x] Suite 19 extended from 83 to 86 tests (3 iconv regression tests)
- [x] Suite 25 passes 9/9 (lint + self-host fixture)
- [x] Regression-proof: reverting `install.sh`/`update.sh` anchors makes suite 25 lint fail with both buggy sites reported
- [x] Regression-proof: reverting the iconv fix makes suite 19 regression tests fail (word count doubled, static guard tripped)
- [x] `bash -n` clean on all modified `.sh` files
- [x] Shellcheck clean (suite 01 reports `65 passed, 0 failed`)
- [x] Manual smoke: `bash update.sh` in this dogfooded repo regenerates a 75-entry manifest (was 0 with the bug)
- [x] CLAUDE.md standards: POSIX ERE only, `set -euo pipefail`, no `--no-verify`, allowed scopes (`install`, `skills`, `tests`), no AI references in commits

## Acceptance criteria (from #265)

- [x] `update.sh` regenerates a non-empty manifest when run from a project whose path contains `cognitive-core`
- [x] Manifest still excludes `.claude/cognitive-core/` state-directory contents
- [x] Audit other unanchored `cognitive-core` matchers — lint suite IS the audit (AC satisfied when it reports zero violations)
- [x] New CI lint suite fails on any unanchored `*/cognitive-core/*` path-filter matcher (converts bug class into structural invariant)
- [x] Self-host CI fixture installs into a `cognitive-core`-named project and asserts manifest entry count after `install.sh` and `update.sh`