### PR TITLE
docs(session): add 2026-04-21 session log + continuation prompt

### DIFF
--- a/docs/sessions/2026-04-21-session.md
+++ b/docs/sessions/2026-04-21-session.md
@@ -1,0 +1,98 @@
+# Session 2026-04-21 — Hook drift, manifest bug #265, test-suite peer review
+
+Spans 2026-04-21 → 2026-04-23. Major output: PR mindcockpit-ai/cognitive-core#276 (open), 9 new issues filed (mindcockpit-ai/cognitive-core#267-275).
+
+## Headline outcomes
+
+- **mindcockpit-ai/cognitive-core#265** filed, peer-reviewed, propose-prompted, implemented → PR mindcockpit-ai/cognitive-core#276 (open, mergeable, 4 commits, 24/24 suites pass).
+- **Test-suite catalog reviewed** across reliability, assertion quality, stochastic vulnerability — 6 CRITICAL, 11 HIGH, 23 MEDIUM, 8 LOW findings; filed 3 P1 + 1 epic with 5 sub-issues.
+- **`area:testing` label created** (didn't exist; project-board skill doc was outdated).
+
+## Work threads
+
+### 1. Hook drift surfaced at session start
+
+Five `.claude/hooks/*.sh` differed from `core/hooks/*.sh`. Verified to be **stale versions, not local edits** (predated #260 TOFU + orphan-subprocess detection + shared-state gate). Synced via direct copy. Files:
+- `_session-hygiene.sh`, `post-edit-lint.sh`, `session-guard.sh`, `setup-env.sh`, `validate-bash.sh`
+
+The 5 modified hooks remain as uncommitted WIP at session end — not bundled with #265 PR; separate cleanup pending.
+
+### 2. mindcockpit-ai/cognitive-core#265 — update.sh manifest bug discovered + fixed
+
+**Bug:** `update.sh:335` and `install.sh:848` use unanchored glob `find ... -not -path "*/cognitive-core/*"`. When `PROJECT_DIR` path contains the substring `cognitive-core` (always true when dogfooded), every absolute path matches the exclude → `find` returns 0 → manifest `files: []` → `update.sh` becomes a no-op.
+
+**Adapter impact (deeper finding):** `install.sh:191-195` sets `_EARLY_INSTALL_DIR=".cognitive-core"` for `aider`/`intellij`/`vscode` adapters. Those three adapters have **silently shipped empty manifests from day one** because every install path matches the unanchored exclude.
+
+**Strategy peer review** rejected Option C (rename `.claude/cognitive-core/` → `.claude/state/`) — solving the wrong problem; renaming reintroduces the same class for any project named `state-*`. Adopted Option A (anchor matchers + lint suite as structural invariant + self-host CI fixture).
+
+**Secondary finding** during propose validation: `core/skills/project-board/validate-prompt.sh:64` — macOS iconv with `TRANSLIT//IGNORE` exits non-zero whenever any char is transliterated, triggering the `||` fallback that appends the original input → linter doubles its input on em-dash-bearing prompts. Folded into mindcockpit-ai/cognitive-core#265 as AC #6 rather than filed separately.
+
+### 3. mindcockpit-ai/cognitive-core#276 — implementation delegated to project-coordinator
+
+4 commits on `fix/265-anchor-state-matchers`:
+1. `f2fc979` — `fix(install): anchor manifest exclusion to state dir (#265)`
+2. `a24ed9b` — `fix(skills): prevent validate-prompt.sh iconv doubling on macOS (#265)`
+3. `e1459fa` — `test(install): add anchored-state-references suite + iconv regression (#265)`
+4. `33e75a8` — `test(install): drop duplicate CC_SYNC_ENFORCE assignment in suite 25 (#265)` (SC2034 cleanup, new commit per CLAUDE.md "no amend" rule)
+
+Verification: 24/24 suites pass. Suite 19 extended 83 → 86 (3 iconv regression tests). Suite 25 added with 9 tests (1 lint scanner + 8 self-host fixture).
+
+**PR body fix:** caught `Closes #265` after merge — would have bypassed the board approval gate (`CC_REQUIRE_HUMAN_APPROVAL=true`). Replaced with `Refs #265` so CI automation moves the issue to **To Be Tested** rather than auto-closing.
+
+**Installed copy of validate-prompt.sh in `.claude/skills/`** was NOT patched — environment denied the mirror edit. Will sync on next `update.sh` run; not a regression.
+
+### 4. Test-suite catalog peer review (23 suites + helpers)
+
+Three parallel agents reviewed reliability / assertion quality / stochastic vulnerability across all suites.
+
+**Cross-cutting themes:**
+- Missing EXIT traps for temp-dir cleanup (9 suites)
+- Environment leakage (`CC_*` vars in suites 06 + 14)
+- Surface-level `assert_contains` where structural validation (jq/yq) is warranted
+- Hidden tool-skips not surfaced to `run-all.sh`
+- Suite 19 doesn't catch the macOS iconv bug
+
+**Severity distribution:** 6 CRITICAL, 11 HIGH, 23 MEDIUM, 8 LOW.
+
+### 5. New issues filed
+
+| # | Type | Priority | Title |
+|---|------|----------|-------|
+| mindcockpit-ai/cognitive-core#267 | bug | P1 | suite 17 sleep-before-check race on slow CI |
+| mindcockpit-ai/cognitive-core#268 | bug | P1 | EXIT-trap cleanup + suite 04 silent-pass |
+| mindcockpit-ai/cognitive-core#269 | bug | P1 | suite 24 fake-stat shadow mock ignores flags |
+| mindcockpit-ai/cognitive-core#270 | bug | P2 | misc HIGH/MEDIUM across 8 suites |
+| mindcockpit-ai/cognitive-core#271 | bug | P2 | suite 21 snapshot baselines + md5 normalization |
+| mindcockpit-ai/cognitive-core#272 | enh | P2 | structural asserts (jq/yq) in 09/12/14-ADF |
+| mindcockpit-ai/cognitive-core#273 | enh | P2 | surface tool-skip counts to run-all.sh |
+| mindcockpit-ai/cognitive-core#274 | bug | P2 | scrub CC_* env vars in suites 06/14 |
+| mindcockpit-ai/cognitive-core#275 | epic | P2 | harden assertion quality + env isolation (parent of #270-274) |
+
+All labeled `area:testing` (label created this session).
+
+## State at session end
+
+- **PR mindcockpit-ai/cognitive-core#276:** open, mergeable, awaiting CI + merge.
+- **Issue mindcockpit-ai/cognitive-core#265:** In Progress, assigned wolaschka. Will move to To Be Tested via CI automation when #276 merges.
+- **Working tree:** 5 hook files modified (the framework-source sync from session start) — uncommitted, separate cleanup pending.
+- **Branch:** `main` locally; `fix/265-anchor-state-matchers` pushed.
+
+## Open follow-ups
+
+### Immediate (next session)
+1. **Merge mindcockpit-ai/cognitive-core#276** once CI green; then `/project-board approve 265` after CI auto-moves it to To Be Tested.
+2. **Decide on the 5 stale hook WIP** in `.claude/hooks/` — either commit as `chore(hooks): sync installed hooks with framework source` or revert (the #276 PR fix means future `update.sh` runs will keep them in sync automatically).
+
+### Short-term backlog (now blocked-free)
+3. **mindcockpit-ai/cognitive-core#256** (`_cc_validate_framework_source` helper at 9 consumer sites + suite 23) — was the original session-resume continuation point, deferred when #265 surfaced.
+4. **Test-infra P1 fixes** mindcockpit-ai/cognitive-core#267, mindcockpit-ai/cognitive-core#268, mindcockpit-ai/cognitive-core#269 — all small/medium, parallelizable.
+5. **Epic mindcockpit-ai/cognitive-core#275** — schedule 5 sub-issues across upcoming sprints.
+
+### Side findings worth tracking
+- `update.sh` branch-guard side-effect: running `update.sh` inside a feature branch auto-switches to `chore/cognitive-core-sync`. Recovered cleanly during #265 implementation but disruptive in practice. Possible follow-up issue if it bites again.
+- Skill doc `core/skills/project-board/SKILL.md` lists `area:testing` as a valid label — was outdated until this session created it. Doc still correct now, but worth knowing other labels in the doc may not exist either.
+
+## References
+- Strategy peer review: in mindcockpit-ai/cognitive-core#265 body
+- Propose prompt + plan: latest comment on mindcockpit-ai/cognitive-core#265 (collapsed `<details>`)
+- TOFU explanation context: mindcockpit-ai/cognitive-core#260

--- a/docs/sessions/2026-04-23-continuation-prompt.md
+++ b/docs/sessions/2026-04-23-continuation-prompt.md
@@ -1,0 +1,33 @@
+# Continuation prompt — fresh session resume
+
+Self-contained brief for a fresh session. Paste as the first user message after `/session-resume`.
+
+---
+
+Read `docs/sessions/2026-04-21-session.md` first for full context. Summary: PR mindcockpit-ai/cognitive-core#276 is open and mergeable, fixes mindcockpit-ai/cognitive-core#265 (manifest-regen empty-files bug + adapter impact + macOS iconv linter bug). All 24 test suites pass on the branch. Working tree has 5 uncommitted `.claude/hooks/*.sh` files that are framework-source syncs from the prior session.
+
+Order of business:
+
+1. **Check mindcockpit-ai/cognitive-core#276 status.** If CI is green and it's still open, merge it (squash, default commit message). If CI is red, investigate before merging.
+
+2. **Verify CI automation moved mindcockpit-ai/cognitive-core#265 → To Be Tested** after the merge. If it did, run `/project-board approve 265` to move it to Done. If automation didn't fire, debug `cicd/workflows/project-board-automation.yml` against the merged PR's body (we replaced `Closes #265` with `Refs #265` to preserve the approval gate — confirm the workflow's regex still matches `Refs`).
+
+3. **Decide on the 5 stale hook WIP.** `git status` will show modifications to `_session-hygiene.sh`, `post-edit-lint.sh`, `session-guard.sh`, `setup-env.sh`, `validate-bash.sh` — these are framework-source syncs from the session-start hook drift discovery. Now that mindcockpit-ai/cognitive-core#276 is merged and the manifest regenerates correctly, options:
+   - **Commit as `chore(hooks): sync installed hooks with framework source`** — explicit historical record.
+   - **Revert and let `update.sh` re-sync from the now-correct manifest** — cleaner, lets the fixed tooling do its job.
+   Pick whichever, then proceed.
+
+4. **Pick next priority.** All blocked items are now unblocked. Options:
+   - **mindcockpit-ai/cognitive-core#256** — `_cc_validate_framework_source` helper at 9 consumer sites + suite 23. This was the original session-resume continuation before mindcockpit-ai/cognitive-core#265 surfaced.
+   - **mindcockpit-ai/cognitive-core#267/268/269** — three P1 test-infra bugs. Small/medium, can parallelize via project-coordinator delegation.
+   - **mindcockpit-ai/cognitive-core#275 epic** — schedule its 5 sub-issues into upcoming sprints.
+
+   Recommendation: ask user which they want. mindcockpit-ai/cognitive-core#256 is the longest-deferred; the P1 test-infra issues are the highest-leverage (suite 04 silent-pass is masking real install failures right now in CI).
+
+Do NOT start coding before clarifying the choice in step 4. Confirm with the user first. The board approval flow (steps 1-2) can proceed without confirmation since they were planned at the end of the prior session.
+
+Conventions to remember (already in CLAUDE.md but reinforce on cold start):
+- Always reference issues/PRs as `mindcockpit-ai/cognitive-core#N` clickable form.
+- Never bypass the board approval gate — `/project-board approve` is the only path from To Be Tested → Done.
+- Never amend commits; always create new ones (CLAUDE.md rule, enforced by hooks).
+- POSIX ERE only in shell (no `\s`, `\b`, `\w`) for macOS+Linux compatibility.


### PR DESCRIPTION
## Summary

Persistent session artifacts for the 2026-04-21 → 2026-04-23 work span.

- `docs/sessions/2026-04-21-session.md` — full session log: hook drift, manifest-regen bug (#265 → PR #276), test-suite peer review, 9 new issues filed (#267-275), `area:testing` label created.
- `docs/sessions/2026-04-23-continuation-prompt.md` — self-contained brief for resuming in a fresh session.

## Why

Matches the existing convention (`docs/sessions/2026-04-{16,18,20}-*.md` are all committed). Persists working context across machines and gives next-session resume a deterministic anchor. No code changes, no test impact.

## Test plan

- [ ] Render renders correctly on github.com (markdown tables + clickable issue links)
- [ ] Continuation prompt is self-contained — readable cold without prior session context