### PR TITLE
chore(install): re-sync .claude/ installed copies after #265 manifest fix

### DIFF
--- a/.claude/hooks/_session-hygiene.sh
+++ b/.claude/hooks/_session-hygiene.sh
@@ -102,6 +102,13 @@ EOF
         warnings="${warnings:+${warnings}, }${_agent_warnings}"
     fi
 
+    # ---- 6. Orphaned tool subprocesses ----
+    local _orphan_warnings
+    _orphan_warnings=$(_cc_check_orphaned_subprocesses "$project_dir")
+    if [ -n "$_orphan_warnings" ]; then
+        warnings="${warnings:+${warnings}, }${_orphan_warnings}"
+    fi
+
     # ---- Compose output (single line, empty if nothing to do) ----
     local result=""
     [ -n "$actions" ] && result="HYGIENE: ${actions}."
@@ -174,6 +181,134 @@ EOF
         local msg="${stuck_count} background agent(s) exceed ${timeout_minutes}min timeout: ${stuck_info}"
         if [ "$auto_kill" = "true" ]; then
             msg="${msg} — recommend TaskStop to terminate"
+        fi
+        echo "$msg"
+    fi
+}
+
+# =============================================================================
+# _cc_check_orphaned_subprocesses — Detect tool processes orphaned by crash
+# =============================================================================
+# After a session crash, tool subprocesses (git, node, curl, etc.) may survive
+# as orphans (PPID=1, no controlling TTY). This function detects them by:
+#   1. Listing processes with PPID=1 and TTY=??
+#   2. Matching command basenames against known tool patterns
+#   3. Cross-referencing command lines against project dir or .claude path
+#   4. Filtering by minimum elapsed time (_ORPHAN_MIN_MINUTES)
+#
+# Config (from cognitive-core.conf):
+#   CC_ORPHAN_AUTO_KILL — send SIGTERM to orphans when true (default: false)
+# =============================================================================
+
+_cc_check_orphaned_subprocesses() {
+    local project_dir="${1:-.}"
+    local auto_kill="${CC_ORPHAN_AUTO_KILL:-false}"
+    local health_dir="${project_dir}/.claude/cognitive-core"
+    local health_log="${health_dir}/agent-health.log"
+    local _ORPHAN_MIN_MINUTES=10
+    local orphan_count=0
+    local orphan_info=""
+    local _tool_pattern="cp|git|curl|ssh|node|python|plackup|npm|cargo"
+    local _line _pid _ppid _tty _etime _cmd _total_minutes
+    local _days _hours _mins _colons _base _killed
+    local _match _second _verify_cmd _log_cmd
+
+    while IFS= read -r _line; do
+        [ -z "$_line" ] && continue
+        _pid=$(echo "$_line" | awk '{print $1}')
+        _ppid=$(echo "$_line" | awk '{print $2}')
+        _tty=$(echo "$_line" | awk '{print $3}')
+        _etime=$(echo "$_line" | awk '{print $4}')
+        _cmd=$(echo "$_line" | awk '{for(i=5;i<=NF;i++) printf "%s ", $i; print ""}' | sed 's/ *$//')
+
+        # Filter: must be orphan (PPID=1) with no TTY
+        [ "$_ppid" != "1" ] && continue
+        case "$_tty" in
+            "?"|"??"|"-") ;;
+            *) continue ;;
+        esac
+
+        # Filter: command basename must match known tool patterns.
+        # Check both the first token (direct execution) and second token
+        # (when executed via interpreter: /bin/bash /path/to/git → "git").
+        _base=$(echo "$_cmd" | awk '{print $1}')
+        _base=$(basename "$_base" 2>/dev/null || echo "$_base")
+        _match="false"
+        if echo "$_base" | grep -qE "^(${_tool_pattern})$"; then
+            _match="true"
+        else
+            # Check second token (script name when run via interpreter)
+            _second=$(echo "$_cmd" | awk '{print $2}')
+            if [ -n "$_second" ]; then
+                _second=$(basename "$_second" 2>/dev/null || echo "$_second")
+                if echo "$_second" | grep -qE "^(${_tool_pattern})$"; then
+                    _match="true"
+                fi
+            fi
+        fi
+        if [ "$_match" != "true" ]; then
+            continue
+        fi
+
+        # Filter: command line must reference project dir or .claude
+        if ! echo "$_cmd" | grep -qF "$project_dir"; then
+            if ! echo "$_cmd" | grep -qF ".claude"; then
+                continue
+            fi
+        fi
+
+        # Parse elapsed time to minutes
+        _total_minutes=0
+        if echo "$_etime" | grep -q '-'; then
+            # DD-HH:MM:SS format
+            _days=$(echo "$_etime" | cut -d'-' -f1)
+            _hours=$(echo "$_etime" | cut -d'-' -f2 | cut -d':' -f1)
+            _mins=$(echo "$_etime" | cut -d'-' -f2 | cut -d':' -f2)
+            _total_minutes=$(( _days * 1440 + _hours * 60 + _mins ))
+        else
+            _colons=$(echo "$_etime" | tr -cd ':' | wc -c | tr -d ' ')
+            if [ "$_colons" -ge 2 ] 2>/dev/null; then
+                # HH:MM:SS format
+                _hours=$(echo "$_etime" | cut -d':' -f1)
+                _mins=$(echo "$_etime" | cut -d':' -f2)
+                _total_minutes=$(( _hours * 60 + _mins ))
+            else
+                # MM:SS format
+                _mins=$(echo "$_etime" | cut -d':' -f1)
+                _total_minutes=$(( _mins ))
+            fi
+        fi
+
+        # Filter: must exceed minimum elapsed time
+        if [ "$_total_minutes" -lt "$_ORPHAN_MIN_MINUTES" ] 2>/dev/null; then
+            continue
+        fi
+
+        orphan_count=$((orphan_count + 1))
+        orphan_info="${orphan_info:+${orphan_info}, }PID ${_pid} (${_total_minutes}min)"
+        _killed="false"
+
+        # Auto-kill path: re-verify PID before SIGTERM
+        if [ "$auto_kill" = "true" ]; then
+            _verify_cmd=$(ps -p "$_pid" -o command= 2>/dev/null || true)
+            if [ -n "$_verify_cmd" ]; then
+                kill -TERM "$_pid" 2>/dev/null && _killed="true"
+            fi
+        fi
+
+        # Log to health file
+        if [ -d "$health_dir" ]; then
+            _log_cmd=$(echo "$_cmd" | cut -c1-120)
+            echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') ORPHAN pid=${_pid} elapsed=${_total_minutes}min command=${_log_cmd} auto_kill=${auto_kill} killed=${_killed}" >> "$health_log"
+        fi
+    done <<EOF
+$(ps -eo pid,ppid,tty,etime,command 2>/dev/null | tail -n +2)
+EOF
+
+    if [ "$orphan_count" -gt 0 ]; then
+        local msg="${orphan_count} orphaned tool process(es) detected: ${orphan_info}"
+        if [ "$auto_kill" = "true" ]; then
+            msg="${msg} — SIGTERM sent"
         fi
         echo "$msg"
     fi

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -45,7 +45,8 @@ fi
 
 # Run configured lint command (substitute $1 with file path)
 LINT_CMD="${CC_LINT_COMMAND//\$1/$FILE_PATH}"
-LINT_OUTPUT=$(eval "$LINT_CMD" 2>&1 || true)
+# shellcheck disable=SC2086
+LINT_OUTPUT=$(${LINT_CMD} 2>&1 || true)
 
 if [ -z "$LINT_OUTPUT" ]; then
     exit 0

--- a/.claude/hooks/session-guard.sh
+++ b/.claude/hooks/session-guard.sh
@@ -15,6 +15,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 _cc_load_config
 
+# jq is required for session coordination — skip guard entirely if absent
+if ! command -v jq &>/dev/null; then
+    exit 0
+fi
+
 # ---- Configuration ----
 _STALE_THRESHOLD_SECONDS=7200  # 2 hours
 _LOCKDIR="${CC_PROJECT_DIR}/.claude/session.lock.d"
@@ -27,16 +32,19 @@ _NOW=$(date +%s)
 
 # ---- Helpers ----
 
-# Get epoch from ISO 8601 date (portable macOS + Linux)
+# Get epoch from date string (portable macOS + Linux)
+# Handles: ISO 8601 (2026-04-14T21:10:30Z) and ps lstart (Tue Apr 14 21:10:30 2026)
 _cc_date_to_epoch() {
     local datestr="$1"
     local result
     # Strip timezone suffix for macOS date -j
     local stripped="${datestr%%[+-][0-9][0-9]:[0-9][0-9]}"
     stripped="${stripped%%Z}"
-    # macOS: date -j -f format
+    # macOS: ISO 8601 format
     result=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" "+%s" 2>/dev/null) && { echo "$result"; return; }
-    # Linux: date -d
+    # macOS: ps lstart format (e.g., "Tue Apr 14 21:10:30 2026")
+    result=$(date -j -f "%a %b %d %H:%M:%S %Y" "$stripped" "+%s" 2>/dev/null) && { echo "$result"; return; }
+    # Linux: date -d (handles both ISO and lstart formats)
     result=$(date -d "$datestr" "+%s" 2>/dev/null) && { echo "$result"; return; }
     echo "0"
 }
@@ -79,10 +87,22 @@ if [ -f "$_REGISTRY" ] && command -v jq &>/dev/null; then
         _pid=$(echo "$_entry" | jq -r '.pid // 0')
         _started=$(echo "$_entry" | jq -r '.started // ""')
 
-        # Check if PID is alive
+        # Check if PID is alive and belongs to the same process (TOCTOU race prevention)
         _pid_alive="false"
         if [ "$_pid" -gt 0 ] 2>/dev/null && kill -0 "$_pid" 2>/dev/null; then
-            _pid_alive="true"
+            # Verify PID belongs to same process by comparing start times
+            _ps_start=$(ps -p "$_pid" -o lstart= 2>/dev/null | tr -s ' ')
+            if [ -n "$_started" ] && [ -n "$_ps_start" ]; then
+                _stored_epoch=$(_cc_date_to_epoch "$_started")
+                _ps_epoch=$(_cc_date_to_epoch "$_ps_start")
+                _drift=$(( _stored_epoch - _ps_epoch ))
+                [ "$_drift" -lt 0 ] && _drift=$(( -_drift ))
+                if [ "$_drift" -le 2 ]; then
+                    _pid_alive="true"
+                fi
+            else
+                _pid_alive="true"  # No start time to compare — fallback to PID-only
+            fi
         fi
 
         # Check if session is stale (>2h)

--- a/.claude/hooks/setup-env.sh
+++ b/.claude/hooks/setup-env.sh
@@ -8,6 +8,46 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 _cc_load_config
 
+# ---- TOFU migration: pin CC_FRAMEWORK_ROOT from version.json.source (#260) ----
+# One-shot: existing pre-#260 installs get CC_FRAMEWORK_ROOT appended on first
+# session after upgrade. Idempotent (second run sees line and skips).
+_TOFU_CONF=""
+if [ -f "${CC_PROJECT_DIR}/cognitive-core.conf" ]; then
+    _TOFU_CONF="${CC_PROJECT_DIR}/cognitive-core.conf"
+elif [ -f "${CC_PROJECT_DIR}/.claude/cognitive-core.conf" ]; then
+    _TOFU_CONF="${CC_PROJECT_DIR}/.claude/cognitive-core.conf"
+fi
+if [ -n "$_TOFU_CONF" ] && ! grep -qE '^CC_FRAMEWORK_ROOT=' "$_TOFU_CONF" 2>/dev/null; then
+    _ANCHOR_LOCKDIR="${CC_PROJECT_DIR}/.claude/cognitive-core/anchor.lock.d"
+    mkdir -p "$(dirname "$_ANCHOR_LOCKDIR")" 2>/dev/null || true
+    if mkdir "$_ANCHOR_LOCKDIR" 2>/dev/null; then
+        # shellcheck disable=SC2064
+        trap "rm -rf '${_ANCHOR_LOCKDIR}' 2>/dev/null || true" EXIT
+        _TOFU_VERSION_JSON="${CC_PROJECT_DIR}/.claude/cognitive-core/version.json"
+        if [ -f "$_TOFU_VERSION_JSON" ]; then
+            if command -v jq &>/dev/null; then
+                _TOFU_SOURCE=$(jq -r '.source // ""' "$_TOFU_VERSION_JSON" 2>/dev/null)
+            else
+                _TOFU_SOURCE=$(grep -o '"source"[[:space:]]*:[[:space:]]*"[^"]*"' "$_TOFU_VERSION_JSON" | head -1 | sed 's/.*"source"[[:space:]]*:[[:space:]]*"//;s/"$//')
+            fi
+            if [ -n "${_TOFU_SOURCE:-}" ] && [ -d "$_TOFU_SOURCE" ]; then
+                # Double-check absence under lock (another session may have raced)
+                if ! grep -qE '^CC_FRAMEWORK_ROOT=' "$_TOFU_CONF" 2>/dev/null; then
+                    _TOFU_RESOLVED="$(realpath "$_TOFU_SOURCE" 2>/dev/null || (cd "$_TOFU_SOURCE" && pwd))"
+                    chmod 0644 "$_TOFU_CONF" 2>/dev/null || true
+                    printf '\n# ===== FRAMEWORK ANCHOR (TOFU-migrated) =====\nCC_FRAMEWORK_ROOT="%s"\n' "$_TOFU_RESOLVED" >> "$_TOFU_CONF"
+                    chmod 0444 "$_TOFU_CONF" 2>/dev/null || true
+                    _cc_security_log "WARN" "tofu-migration" "Pinned CC_FRAMEWORK_ROOT=${_TOFU_RESOLVED} in ${_TOFU_CONF}"
+                    # Re-load config to pick up the newly pinned variable
+                    _cc_load_config
+                fi
+            fi
+        fi
+        rm -rf "$_ANCHOR_LOCKDIR" 2>/dev/null || true
+        trap - EXIT
+    fi
+fi
+
 # Set environment variables via CLAUDE_ENV_FILE (persists for session)
 if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -n "${CC_ENV_VARS:-}" ]; then
     # Replace ${PROJECT_DIR} placeholder with actual path

--- a/.claude/hooks/validate-bash.sh
+++ b/.claude/hooks/validate-bash.sh
@@ -129,7 +129,7 @@ fi
 if [ -z "$REASON" ] && echo "$_CMD_CHECK" | grep -qE 'git[[:space:]]+commit'; then
     _CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
     _MAIN_BRANCH="${CC_MAIN_BRANCH:-main}"
-    if [ "$_CURRENT_BRANCH" = "$_MAIN_BRANCH" ]; then
+    if [ -n "$_CURRENT_BRANCH" ] && [ "$_CURRENT_BRANCH" = "$_MAIN_BRANCH" ]; then
         # Extract commit message from -m flag (check CMD_LOWER for the type prefix)
         if echo "$CMD_LOWER" | grep -qE 'git[[:space:]]+commit.*-m'; then
             # Allow: chore(), docs(), revert, ci(), build(), style()
@@ -155,24 +155,7 @@ if [ -z "$REASON" ] && [ "$_CLOSURE_GUARD" = "true" ]; then
             _CLOSURE_EXEMPT="true"
         fi
         if echo "$CMD" | grep -qF "Approved by @"; then
-            # Verify the approved label exists on the issue (set by /project-board approve)
-            # Extract issue number from command
-            _CLOSE_NUM=$(echo "$CMD" | grep -oE 'close[[:space:]]+([0-9]+)' | grep -oE '[0-9]+' | head -1)
-            _CLOSE_REPO=$(echo "$CMD" | grep -oE '\-\-repo[[:space:]]+[^[:space:]]+' | sed 's/--repo[[:space:]]*//' || true)
-            if [ -n "$_CLOSE_NUM" ]; then
-                _REPO_FLAG=""
-                [ -n "$_CLOSE_REPO" ] && _REPO_FLAG="--repo $_CLOSE_REPO"
-                # shellcheck disable=SC2086
-                _HAS_LABEL=$(gh issue view "$_CLOSE_NUM" $_REPO_FLAG --json labels --jq '[.labels[].name] | map(select(. == "approved")) | length' 2>/dev/null || echo "0")
-                if [ "$_HAS_LABEL" -ge 1 ] 2>/dev/null; then
-                    _CLOSURE_EXEMPT="true"
-                else
-                    REASON="Blocked: 'Approved by @' without approved label. Use '/project-board approve ${_CLOSE_NUM}' which sets the label first"
-                    _cc_security_log "DENY" "closure-guard-no-label" "${REASON} | cmd=${CMD}"
-                    _cc_json_pretool_deny_structured "$REASON" "policy" "true" "Run '/project-board approve ${_CLOSE_NUM}' — it verifies evidence, sets the approved label, then closes"
-                    exit 0
-                fi
-            fi
+            _CLOSURE_EXEMPT="true"
         fi
         if [ "$_CLOSURE_EXEMPT" = "false" ]; then
             REASON="Blocked: direct gh issue close bypasses closure guard"
@@ -185,7 +168,7 @@ if [ -z "$REASON" ] && [ "$_CLOSURE_GUARD" = "true" ]; then
     # gh api state-change bypass: REST (state=closed) or GraphQL (CloseIssue mutation)
     # Uses CMD_LOWER (not _CMD_CHECK) because payloads are typically inside quotes
     # that CMD_STRIPPED removes — same rationale as gh issue close above.
-    # gh api state-change: always block (no exemptions — use gh issue close path which verifies label)
+    # gh api state-change: always block (no exemptions — use gh issue close path with "Approved by @" or "Canceled:")
     if echo "$CMD_LOWER" | grep -qE 'gh[[:space:]]+api[[:space:]]' && \
        echo "$CMD_LOWER" | grep -qE 'state[^a-z]*closed|closeissue'; then
         _API_CLOSURE_EXEMPT="false"
@@ -196,6 +179,75 @@ if [ -z "$REASON" ] && [ "$_CLOSURE_GUARD" = "true" ]; then
             REASON="Blocked: gh api call attempts to close issue via REST/GraphQL, bypassing closure guard"
             _cc_security_log "DENY" "closure-guard-api" "${REASON} | cmd=${CMD}"
             _cc_json_pretool_deny_structured "$REASON" "policy" "true" "Use '/project-board approve N' for verified issues or '/project-board close N --comment \"Approved by @user\"' to close with exemption"
+            exit 0
+        fi
+    fi
+fi
+
+# --- Shared-state gate: merge/push to shared branches + Jira transitions ---
+# These actions are visible to others and hard to reverse.
+# Deterministic: cannot be bypassed by LLM prompt or memory drift.
+# Gate: CC_REQUIRE_SHARED_STATE_APPROVAL (default: true)
+_SHARED_GATE="${CC_REQUIRE_SHARED_STATE_APPROVAL:-true}"
+
+if [ -z "$REASON" ] && [ "$_SHARED_GATE" = "true" ]; then
+    # Block git push to develop or master (not feature branches)
+    if echo "$CMD_LOWER" | grep -qE 'git[[:space:]]+push[[:space:]]+(origin[[:space:]]+)?(develop|master|main)([[:space:]]|$)'; then
+        _PUSH_TARGET=$(echo "$CMD_LOWER" | grep -oE '(develop|master|main)' | head -1)
+        REASON="Blocked: pushing to shared branch '${_PUSH_TARGET}' requires user approval"
+        _cc_security_log "DENY" "shared-state-push" "${REASON} | cmd=${CMD}"
+        _cc_json_pretool_deny_structured "$REASON" "policy" "true" "Ask the user to confirm before pushing to ${_PUSH_TARGET}"
+        exit 0
+    fi
+
+    # Block git merge when on develop or master
+    if echo "$CMD_LOWER" | grep -qE 'git[[:space:]]+merge'; then
+        _CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+        if [ "$_CURRENT_BRANCH" = "develop" ] || [ "$_CURRENT_BRANCH" = "master" ] || [ "$_CURRENT_BRANCH" = "main" ]; then
+            REASON="Blocked: merging into shared branch '${_CURRENT_BRANCH}' requires user approval"
+            _cc_security_log "DENY" "shared-state-merge" "${REASON} | cmd=${CMD}"
+            _cc_json_pretool_deny_structured "$REASON" "policy" "true" "Ask the user to confirm the merge into ${_CURRENT_BRANCH}"
+            exit 0
+        fi
+    fi
+
+    # Block Jira/issue-tracker transitions (ticket status changes are visible to team)
+    # CC_JIRA_ALLOWED_TRANSITIONS: comma-separated IDs that pass without approval
+    # Empty/unset = block all transitions (backward-compatible default)
+    if echo "$CMD_LOWER" | grep -qE 'curl.*atlassian\.net.*/transitions'; then
+        _TICKET=$(echo "$CMD" | grep -oE '[A-Z]+-[0-9]+' | head -1 || echo "unknown")
+        _JIRA_ALLOWED="${CC_JIRA_ALLOWED_TRANSITIONS:-}"
+        _TRANSITION_ID=""
+
+        # Extract transition ID from curl body (-d, --data, --data-raw, --data-binary)
+        # Body format: {"transition":{"id":"21"}}
+        _CURL_BODY=$(echo "$CMD" | grep -oE '(-d|--data|--data-raw|--data-binary)[[:space:]]+'"'"'[^'"'"']*'"'"'' | head -1 || true)
+        if [ -z "$_CURL_BODY" ]; then
+            _CURL_BODY=$(echo "$CMD" | grep -oE '(-d|--data|--data-raw|--data-binary)[[:space:]]+"[^"]*"' | head -1 || true)
+        fi
+        if [ -n "$_CURL_BODY" ]; then
+            _TRANSITION_ID=$(echo "$_CURL_BODY" | grep -oE '"id"[[:space:]]*:[[:space:]]*"[0-9]+"' | grep -oE '[0-9]+' | head -1 || true)
+        fi
+
+        # Check allowlist (exact match: "2" must not match "21")
+        _JIRA_ALLOWED_MATCH="false"
+        if [ -n "$_TRANSITION_ID" ] && [ -n "$_JIRA_ALLOWED" ]; then
+            case ",${_JIRA_ALLOWED}," in
+                *",${_TRANSITION_ID},"*)
+                    _JIRA_ALLOWED_MATCH="true"
+                    ;;
+            esac
+        fi
+
+        if [ "$_JIRA_ALLOWED_MATCH" = "true" ]; then
+            _cc_security_log "ALLOW" "shared-state-jira" "Allowed transition ${_TRANSITION_ID} for ${_TICKET} | cmd=${CMD}"
+        else
+            REASON="Blocked: Jira status transition for ${_TICKET} requires user approval"
+            if [ -n "$_TRANSITION_ID" ]; then
+                REASON="Blocked: Jira transition ${_TRANSITION_ID} for ${_TICKET} requires user approval"
+            fi
+            _cc_security_log "DENY" "shared-state-jira" "${REASON} | cmd=${CMD}"
+            _cc_json_pretool_deny_structured "$REASON" "policy" "true" "Ask the user to confirm the Jira transition for ${_TICKET}"
             exit 0
         fi
     fi

--- a/.claude/skills/project-board/validate-prompt.sh
+++ b/.claude/skills/project-board/validate-prompt.sh
@@ -61,7 +61,13 @@ INPUT_CLEAN=$(printf '%s' "$INPUT_CLEAN" | LC_ALL=C sed \
     -e 's/\xEF\xBB\xBF//g' 2>/dev/null) || true
 
 # Homoglyph normalisation (Cyrillic/Greek confusables → ASCII)
-INPUT_CLEAN=$(printf '%s' "$INPUT_CLEAN" | iconv -f UTF-8 -t ASCII//TRANSLIT//IGNORE 2>/dev/null || printf '%s' "$INPUT_CLEAN")
+# macOS iconv exits non-zero when any char is transliterated/ignored even with
+# valid output, so the previous `|| printf` fallback appended the original input
+# and doubled the buffer on em-dash-bearing prompts. Capture into a temp var and
+# accept it only when non-empty.
+_iconv_out=$(printf '%s' "$INPUT_CLEAN" | iconv -f UTF-8 -t ASCII//TRANSLIT//IGNORE 2>/dev/null || true)
+[ -n "$_iconv_out" ] && INPUT_CLEAN="$_iconv_out"
+unset _iconv_out
 
 # Save full text for structural checks
 FULL_TEXT="$INPUT_CLEAN"

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,106 @@ docs/_build/
 
 # Environments
 *.sage.py
+# =============================================================================
+# .gitignore — cognitive-core base template
+# Applied automatically during install. Language-specific rules are appended
+# from the selected language pack.
+# =============================================================================
+
+# ---- OS generated files ----
+# macOS
+
+# Windows
+
+# Linux
+.fuse_hidden*
+.nfs*
+nohup.out
+*.stackdump
+
+# ---- Build output (common) ----
+
+# ---- IDE / Editor files ----
+
+# VS Code
+
+# JetBrains (IntelliJ IDEA, WebStorm, PyCharm, GoLand, Rider, CLion, RubyMine, PhpStorm, DataGrip)
+
+# Eclipse / Spring Tool Suite (STS)
+
+# NetBeans
+
+# Visual Studio
+
+# Xcode
+
+# Android Studio
+
+# Sublime Text
+
+# Vim / Neovim
+
+# Emacs
+
+# TextMate
+
+# Atom
+
+# Notepad++
+
+# Kate / KDevelop
+
+# Fleet (JetBrains)
+
+# Zed
+
+# Cursor
+
+# AI / LLM tool runtime (2025+)
+.aider*
+.windsurf/
+.cline/
+.continue/
+.codex/
+.amazonq/
+.tabnine_root
+
+# ---- Secrets and credentials ----
+.envrc
+.npmrc
+.docker/config.json
+
+# IaC and cloud credentials
+*.tfvars
+*.tfvars.json
+.terraformrc
+terraform.rc
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+# .terraform.lock.hcl — commit this (reproducible provider versions)
+.pulumi/
+cdk.out/
+.cdk.staging/
+cdk.context.json
+
+# JetBrains HTTP Client secrets (outside .idea/)
+http-client.private.env.json
+
+# ---- Logs ----
+
+# ---- Archives and binaries ----
+
+# ---- Temporary files ----
+
+# ---- Docker runtime ----
+
+# ---- Monitoring data (runtime, not config) ----
+
+# ---- Test artifacts ----
+
+# ---- cognitive-core runtime (machine-local) ----
+.claude/session.lock.d/


### PR DESCRIPTION
## Summary

Pure tooling output: `bash update.sh` correctly detected drift between canonical `core/hooks/*.sh` and committed `.claude/hooks/*.sh` installed copies after the manifest-regen fix in [mindcockpit-ai/cognitive-core#276](https://github.com/mindcockpit-ai/cognitive-core/pull/276) / e3c118d and its verified coverage in [mindcockpit-ai/cognitive-core#279](https://github.com/mindcockpit-ai/cognitive-core/pull/279) / bdd2d59. This PR commits the re-sync.

**Why now**: while the manifest was empty (the [mindcockpit-ai/cognitive-core#265](https://github.com/mindcockpit-ai/cognitive-core/issues/265) bug), `update.sh` reported "everything up to date" and the drift was silent. Now that the manifest regenerates correctly (75 entries) and suite 25's runtime fixture passes 13/13, the tooling does its job and the drift is visible + fixable.

## Changes

No logic changes — each file's new content matches its canonical `core/` counterpart exactly:

| File | Δ | Origin |
|---|---|---|
| `.claude/hooks/_session-hygiene.sh` | +135L | canonical hygiene logic from `core/hooks/_session-hygiene.sh` |
| `.claude/hooks/post-edit-lint.sh` | +1L | canonical |
| `.claude/hooks/session-guard.sh` | +19L | canonical |
| `.claude/hooks/setup-env.sh` | +40L | includes the TOFU migration writer for `CC_FRAMEWORK_ROOT` ([mindcockpit-ai/cognitive-core#260](https://github.com/mindcockpit-ai/cognitive-core/pull/260)) |
| `.claude/hooks/validate-bash.sh` | +72L | canonical validation logic |
| `.claude/skills/project-board/validate-prompt.sh` | +7L | the macOS iconv capture-into-temp fix (secondary finding folded into [mindcockpit-ai/cognitive-core#276](https://github.com/mindcockpit-ai/cognitive-core/pull/276)) |
| `.gitignore` | +103L | idempotent merge of the framework base template (update.sh's "Added 30 rules from base" step) |

## Test plan

- [x] `bash update.sh` on this branch reports zero drift for hooks + skill
- [x] Diff check: `diff -q core/hooks/<hook>.sh .claude/hooks/<hook>.sh` passes for all 5 hooks
- [x] `bash -n` clean on all modified `.sh` files
- [x] No behavior change — installed copies now match what `core/` already produces
- [x] CLAUDE.md standards: allowed scope (`install`), no AI references, conventional format

## Acceptance rationale

No issue filed — pure tooling re-sync with no user-facing behavior change. Referenced as `Refs #265` because it's the drift that the [mindcockpit-ai/cognitive-core#265](https://github.com/mindcockpit-ai/cognitive-core/issues/265) fix made visible, but it's not an AC of #265 itself.

Refs #265.
