### PR TITLE
fix(hooks): validate-bash branch/merge guards respect leading "cd <path>" (#283)

### DIFF
--- a/.claude/hooks/validate-bash.sh
+++ b/.claude/hooks/validate-bash.sh
@@ -9,6 +9,41 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 _cc_load_config
 
+# Extract leading "cd <path>" from a bash command so branch-aware guards
+# inspect the actual target repo, not Claude Code's harness cwd.
+# Returns empty if no leading cd, or the path is not an existing directory.
+_cc_target_dir_from_cmd() {
+    local cmd="$1"
+    local first_line raw
+    first_line=$(printf '%s' "$cmd" | head -n 1)
+    raw=$(printf '%s' "$first_line" \
+        | grep -oE '^[[:space:]]*cd[[:space:]]+("[^"]+"|'"'"'[^'"'"']+'"'"'|[^[:space:];&|]+)' \
+        | head -1 \
+        | sed -E 's/^[[:space:]]*cd[[:space:]]+//' \
+        | sed -E 's/^"(.*)"$/\1/' \
+        | sed -E "s/^'(.*)'\$/\\1/")
+    if [ -n "$raw" ] && [ -d "$raw" ]; then
+        printf '%s' "$raw"
+    fi
+}
+
+# Current branch lookup that respects a leading "cd <dir>" in the command.
+# Falls back to harness-cwd lookup when the target is not a git repo, so a
+# malicious "cd /tmp && cd /repo-on-main && git commit" cannot bypass the
+# branch guard by parking the parser on a non-repo first cd.
+_cc_branch_from_cmd() {
+    local target branch
+    target=$(_cc_target_dir_from_cmd "$1")
+    if [ -n "$target" ]; then
+        branch=$(git -C "$target" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+        if [ -n "$branch" ]; then
+            printf '%s' "$branch"
+            return
+        fi
+    fi
+    git rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
 # Read stdin JSON
 INPUT=$(cat)
 
@@ -127,7 +162,7 @@ fi
 # Agents should work on feature branches, not commit directly to main.
 # Allowed on main: chore(), docs(), revert, merge commits, and git push.
 if [ -z "$REASON" ] && echo "$_CMD_CHECK" | grep -qE 'git[[:space:]]+commit'; then
-    _CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    _CURRENT_BRANCH=$(_cc_branch_from_cmd "$CMD")
     _MAIN_BRANCH="${CC_MAIN_BRANCH:-main}"
     if [ -n "$_CURRENT_BRANCH" ] && [ "$_CURRENT_BRANCH" = "$_MAIN_BRANCH" ]; then
         # Extract commit message from -m flag (check CMD_LOWER for the type prefix)
@@ -202,7 +237,7 @@ if [ -z "$REASON" ] && [ "$_SHARED_GATE" = "true" ]; then
 
     # Block git merge when on develop or master
     if echo "$CMD_LOWER" | grep -qE 'git[[:space:]]+merge'; then
-        _CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+        _CURRENT_BRANCH=$(_cc_branch_from_cmd "$CMD")
         if [ "$_CURRENT_BRANCH" = "develop" ] || [ "$_CURRENT_BRANCH" = "master" ] || [ "$_CURRENT_BRANCH" = "main" ]; then
             REASON="Blocked: merging into shared branch '${_CURRENT_BRANCH}' requires user approval"
             _cc_security_log "DENY" "shared-state-merge" "${REASON} | cmd=${CMD}"

--- a/core/hooks/validate-bash.sh
+++ b/core/hooks/validate-bash.sh
@@ -9,6 +9,41 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 _cc_load_config
 
+# Extract leading "cd <path>" from a bash command so branch-aware guards
+# inspect the actual target repo, not Claude Code's harness cwd.
+# Returns empty if no leading cd, or the path is not an existing directory.
+_cc_target_dir_from_cmd() {
+    local cmd="$1"
+    local first_line raw
+    first_line=$(printf '%s' "$cmd" | head -n 1)
+    raw=$(printf '%s' "$first_line" \
+        | grep -oE '^[[:space:]]*cd[[:space:]]+("[^"]+"|'"'"'[^'"'"']+'"'"'|[^[:space:];&|]+)' \
+        | head -1 \
+        | sed -E 's/^[[:space:]]*cd[[:space:]]+//' \
+        | sed -E 's/^"(.*)"$/\1/' \
+        | sed -E "s/^'(.*)'\$/\\1/")
+    if [ -n "$raw" ] && [ -d "$raw" ]; then
+        printf '%s' "$raw"
+    fi
+}
+
+# Current branch lookup that respects a leading "cd <dir>" in the command.
+# Falls back to harness-cwd lookup when the target is not a git repo, so a
+# malicious "cd /tmp && cd /repo-on-main && git commit" cannot bypass the
+# branch guard by parking the parser on a non-repo first cd.
+_cc_branch_from_cmd() {
+    local target branch
+    target=$(_cc_target_dir_from_cmd "$1")
+    if [ -n "$target" ]; then
+        branch=$(git -C "$target" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+        if [ -n "$branch" ]; then
+            printf '%s' "$branch"
+            return
+        fi
+    fi
+    git rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
 # Read stdin JSON
 INPUT=$(cat)
 
@@ -127,7 +162,7 @@ fi
 # Agents should work on feature branches, not commit directly to main.
 # Allowed on main: chore(), docs(), revert, merge commits, and git push.
 if [ -z "$REASON" ] && echo "$_CMD_CHECK" | grep -qE 'git[[:space:]]+commit'; then
-    _CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    _CURRENT_BRANCH=$(_cc_branch_from_cmd "$CMD")
     _MAIN_BRANCH="${CC_MAIN_BRANCH:-main}"
     if [ -n "$_CURRENT_BRANCH" ] && [ "$_CURRENT_BRANCH" = "$_MAIN_BRANCH" ]; then
         # Extract commit message from -m flag (check CMD_LOWER for the type prefix)
@@ -202,7 +237,7 @@ if [ -z "$REASON" ] && [ "$_SHARED_GATE" = "true" ]; then
 
     # Block git merge when on develop or master
     if echo "$CMD_LOWER" | grep -qE 'git[[:space:]]+merge'; then
-        _CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+        _CURRENT_BRANCH=$(_cc_branch_from_cmd "$CMD")
         if [ "$_CURRENT_BRANCH" = "develop" ] || [ "$_CURRENT_BRANCH" = "master" ] || [ "$_CURRENT_BRANCH" = "main" ]; then
             REASON="Blocked: merging into shared branch '${_CURRENT_BRANCH}' requires user approval"
             _cc_security_log "DENY" "shared-state-merge" "${REASON} | cmd=${CMD}"

--- a/tests/suites/06-security-hooks.sh
+++ b/tests/suites/06-security-hooks.sh
@@ -266,6 +266,57 @@ if [ -f "$VALIDATE_BASH" ]; then
     else
         _fail "bash: minimal mode should not block exfiltration"
     fi
+
+    # --- Branch guard: cd-aware target detection (#283) ---
+    _BG_MAIN_REPO=$(mktemp -d "${TMPDIR:-/tmp}/cc-bg-main-XXXXXX")
+    _BG_FEAT_REPO=$(mktemp -d "${TMPDIR:-/tmp}/cc-bg-feat-XXXXXX")
+    _BG_NON_REPO=$(mktemp -d "${TMPDIR:-/tmp}/cc-bg-nonrepo-XXXXXX")
+    (cd "$_BG_MAIN_REPO" && git init -q -b main && \
+        git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init) >/dev/null 2>&1
+    (cd "$_BG_FEAT_REPO" && git init -q -b feat-x && \
+        git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init) >/dev/null 2>&1
+
+    # T1: cd to repo on feature branch + feat: -> allow (was a false positive before #283)
+    output=$(cd "$_BG_NON_REPO" && echo "$(mock_bash_json "cd $_BG_FEAT_REPO && git commit -m \"feat: ok\"")" | bash "$VALIDATE_BASH" 2>/dev/null) || true
+    if [ -z "$output" ] || ! echo "$output" | grep -q '"deny"'; then
+        _pass "bash: cd to feature-branch repo, feat: -> allow"
+    else
+        _fail "bash: cd to feature-branch repo should allow feat:" "$output"
+    fi
+
+    # T2: cd to repo on main + feat: -> deny
+    output=$(cd "$_BG_NON_REPO" && echo "$(mock_bash_json "cd $_BG_MAIN_REPO && git commit -m \"feat: nope\"")" | bash "$VALIDATE_BASH" 2>/dev/null) || true
+    if echo "$output" | grep -q '"deny"'; then
+        _pass "bash: cd to main repo, feat: -> deny"
+    else
+        _fail "bash: cd to main repo should deny feat:" "$output"
+    fi
+
+    # T3: cd to non-repo from a harness on main -> deny (bypass closed)
+    output=$(cd "$_BG_MAIN_REPO" && echo "$(mock_bash_json "cd /tmp && git commit -m \"feat: bypass\"")" | bash "$VALIDATE_BASH" 2>/dev/null) || true
+    if echo "$output" | grep -q '"deny"'; then
+        _pass "bash: cd to non-repo from main harness -> deny (fallback)"
+    else
+        _fail "bash: cd to non-repo bypass should fall back and deny" "$output"
+    fi
+
+    # T4: cd inside commit message doesn't fool parser
+    output=$(cd "$_BG_MAIN_REPO" && echo "$(mock_bash_json "git commit -m \"feat: cd /etc inside\"")" | bash "$VALIDATE_BASH" 2>/dev/null) || true
+    if echo "$output" | grep -q '"deny"'; then
+        _pass "bash: cd inside commit message doesn't bypass"
+    else
+        _fail "bash: cd inside commit message should still deny feat: on main" "$output"
+    fi
+
+    # T5: cd to repo on main + docs: -> allow (existing exempt prefix still works)
+    output=$(cd "$_BG_NON_REPO" && echo "$(mock_bash_json "cd $_BG_MAIN_REPO && git commit -m \"docs: ok\"")" | bash "$VALIDATE_BASH" 2>/dev/null) || true
+    if [ -z "$output" ] || ! echo "$output" | grep -q '"deny"'; then
+        _pass "bash: cd to main repo, docs: -> allow"
+    else
+        _fail "bash: cd to main repo should allow docs:" "$output"
+    fi
+
+    rm -rf "$_BG_MAIN_REPO" "$_BG_FEAT_REPO" "$_BG_NON_REPO"
 else
     _skip "validate-bash.sh not found"
 fi


### PR DESCRIPTION
## Summary

Closes #283.

The branch and merge guards in `validate-bash.sh` ran `git rev-parse` from the hook's cwd, missing any `cd <target>` prefix in the inspected command. False positives when Claude Code's harness sat in project A but the command was `cd /repo/B && git commit ...`.

## Changes

- New helpers in `core/hooks/validate-bash.sh`:
  - `_cc_target_dir_from_cmd`: parses leading `cd "<path>" | cd '<path>' | cd <path>` followed by `&&|;|||`, only the first line of the command, returns empty if path missing.
  - `_cc_branch_from_cmd`: runs `git -C <target>` when target is a git repo; **falls back to harness-cwd lookup** otherwise (closes a chained-cd bypass).
- Branch-guard (line ~130) and merge-guard (line ~205) now use the helper.
- `git push` guard unchanged — already matches destination in command string.
- Mirrored to `.claude/hooks/validate-bash.sh` (dogfood).

## Bypass scenarios closed by the fallback

- `cd /tmp && git commit -m \"feat: ...\"` — /tmp not a git repo → fallback to harness-cwd → still blocks if harness is on main.
- `cd /tmp && cd /repo-on-main && git commit -m \"feat: ...\"` — parser sees only first cd, /tmp not a repo → fallback → still blocks.

## Tests

- 5 new cases in \`06-security-hooks.sh\` (cd to feature-branch repo, cd to main repo, non-repo bypass, cd inside message, exempt prefix on main repo) — all pass.
- 76/76 in \`06-security-hooks.sh\` (was 71, +5).
- Pre-existing failures in \`07-agent-permissions.sh\` and \`21-snapshot-regression.sh\` are unrelated (frontmatter on \`project-coordinator\` agent + version.json snapshot drift).

## Test plan

- [x] 5 new branch-guard cases pass
- [x] Existing 71 cases still pass
- [x] Manual smoke: real PJ468746-1311 commit through Claude Code now lands without bypass
- [ ] Reviewer: check the leading-cd regex against any local edge cases I missed