### PR TITLE
fix(cicd): harden project-board automation against silent gh failures (#285)

### DIFF
--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
-          set -o pipefail
+          set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then
             echo "::warning::PROJECT_PAT not configured — skipping board automation"
             exit 0
@@ -73,9 +73,9 @@ jobs:
             echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
-          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
-            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
-            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+          if ! printf '%s' "$ITEMS" | jq -e 'type == "object" and has("items") and (.items | type == "array")' >/dev/null 2>&1; then
+            echo "::warning::gh returned non-JSON or unexpected shape (likely auth, rate-limit, scope drift, or truncated response)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | tr -c '[:print:]' '?' | head -c 80)"
             exit 0
           fi
 
@@ -120,7 +120,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
-          set -o pipefail
+          set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
           PR_BODY=$(cat <<'PREOF'
           ${{ github.event.pull_request.body }}
@@ -139,9 +139,9 @@ jobs:
             echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
-          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
-            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
-            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+          if ! printf '%s' "$ITEMS" | jq -e 'type == "object" and has("items") and (.items | type == "array")' >/dev/null 2>&1; then
+            echo "::warning::gh returned non-JSON or unexpected shape (likely auth, rate-limit, scope drift, or truncated response)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | tr -c '[:print:]' '?' | head -c 80)"
             exit 0
           fi
 
@@ -179,16 +179,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
-          set -o pipefail
+          set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
           ISSUE_NUM=${{ github.event.issue.number }}
           ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 | tr -d '\000-\037') || {
             echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
-          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
-            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
-            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+          if ! printf '%s' "$ITEMS" | jq -e 'type == "object" and has("items") and (.items | type == "array")' >/dev/null 2>&1; then
+            echo "::warning::gh returned non-JSON or unexpected shape (likely auth, rate-limit, scope drift, or truncated response)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | tr -c '[:print:]' '?' | head -c 80)"
             exit 0
           fi
 
@@ -230,6 +230,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
+          set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then
             echo "::warning::PROJECT_PAT not configured — new issue not added to board"
             exit 0
@@ -273,16 +274,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
-          set -o pipefail
+          set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
           ISSUE_NUM=${{ github.event.issue.number }}
           ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 | tr -d '\000-\037') || {
             echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
-          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
-            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
-            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+          if ! printf '%s' "$ITEMS" | jq -e 'type == "object" and has("items") and (.items | type == "array")' >/dev/null 2>&1; then
+            echo "::warning::gh returned non-JSON or unexpected shape (likely auth, rate-limit, scope drift, or truncated response)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | tr -c '[:print:]' '?' | head -c 80)"
             exit 0
           fi
 
@@ -323,7 +324,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
           GH_REPO: ${{ github.repository }}
         run: |
-          set -o pipefail
+          set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
           ISSUE_NUM=${{ github.event.issue.number }}
 
@@ -351,9 +352,9 @@ jobs:
               echo "::warning::Cannot access project board — skipping TBT routing for #$ISSUE_NUM (gh exit non-zero)"
               GUARD_ITEMS=""
             }
-            if [ -n "$GUARD_ITEMS" ] && ! printf '%s' "$GUARD_ITEMS" | jq empty 2>/dev/null; then
-              echo "::warning::gh returned non-JSON — skipping TBT routing for #$ISSUE_NUM"
-              echo "First 80 chars: $(printf '%s' "$GUARD_ITEMS" | head -c 80)"
+            if [ -n "$GUARD_ITEMS" ] && ! printf '%s' "$GUARD_ITEMS" | jq -e 'type == "object" and has("items") and (.items | type == "array")' >/dev/null 2>&1; then
+              echo "::warning::gh returned non-JSON or unexpected shape — skipping TBT routing for #$ISSUE_NUM"
+              echo "First 80 chars: $(printf '%s' "$GUARD_ITEMS" | tr -c '[:print:]' '?' | head -c 80)"
               GUARD_ITEMS=""
             fi
             if [ -n "$GUARD_ITEMS" ]; then
@@ -387,9 +388,9 @@ jobs:
             echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
-          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
-            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
-            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+          if ! printf '%s' "$ITEMS" | jq -e 'type == "object" and has("items") and (.items | type == "array")' >/dev/null 2>&1; then
+            echo "::warning::gh returned non-JSON or unexpected shape (likely auth, rate-limit, scope drift, or truncated response)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | tr -c '[:print:]' '?' | head -c 80)"
             exit 0
           fi
 
@@ -424,7 +425,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
           GH_REPO: ${{ github.repository }}
         run: |
-          set -o pipefail
+          set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
 
           # Get all board items, strip control chars
@@ -432,9 +433,9 @@ jobs:
             echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
-          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
-            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
-            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+          if ! printf '%s' "$ITEMS" | jq -e 'type == "object" and has("items") and (.items | type == "array")' >/dev/null 2>&1; then
+            echo "::warning::gh returned non-JSON or unexpected shape (likely auth, rate-limit, scope drift, or truncated response)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | tr -c '[:print:]' '?' | head -c 80)"
             exit 0
           fi
 

--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
+          set -o pipefail
           if [ -z "$GH_TOKEN" ]; then
             echo "::warning::PROJECT_PAT not configured — skipping board automation"
             exit 0
@@ -68,10 +69,15 @@ jobs:
             exit 0
           fi
 
-          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 2>&1 | tr -d '\000-\037') || {
-            echo "::warning::Cannot access project board (ensure PROJECT_PAT has repo, project, and read:org scopes)"
+          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 | tr -d '\000-\037') || {
+            echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
+          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
+            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+            exit 0
+          fi
 
           for ISSUE_NUM in $ISSUES; do
             ITEM_ID=$(echo "$ITEMS" | jq -r --argjson n "$ISSUE_NUM" \
@@ -114,6 +120,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
+          set -o pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
           PR_BODY=$(cat <<'PREOF'
           ${{ github.event.pull_request.body }}
@@ -128,10 +135,15 @@ jobs:
             exit 0
           fi
 
-          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 2>&1 | tr -d '\000-\037') || {
-            echo "::warning::Cannot access project board (ensure PROJECT_PAT has repo, project, and read:org scopes)"
+          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 | tr -d '\000-\037') || {
+            echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
+          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
+            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+            exit 0
+          fi
 
           for ISSUE_NUM in $ISSUES; do
             ITEM_ID=$(echo "$ITEMS" | jq -r --argjson n "$ISSUE_NUM" \
@@ -167,12 +179,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
+          set -o pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
           ISSUE_NUM=${{ github.event.issue.number }}
-          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 2>&1 | tr -d '\000-\037') || {
-            echo "::warning::Cannot access project board (ensure PROJECT_PAT has repo, project, and read:org scopes)"
+          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 | tr -d '\000-\037') || {
+            echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
+          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
+            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+            exit 0
+          fi
 
           ITEM_ID=$(echo "$ITEMS" | jq -r --argjson n "$ISSUE_NUM" \
             '.items[] | select(.content.number == $n) | .id')
@@ -255,12 +273,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
+          set -o pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
           ISSUE_NUM=${{ github.event.issue.number }}
-          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 2>&1 | tr -d '\000-\037') || {
-            echo "::warning::Cannot access project board (ensure PROJECT_PAT has repo, project, and read:org scopes)"
+          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 | tr -d '\000-\037') || {
+            echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
+          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
+            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+            exit 0
+          fi
 
           ITEM_ID=$(echo "$ITEMS" | jq -r --argjson n "$ISSUE_NUM" \
             '.items[] | select(.content.number == $n) | .id')
@@ -299,6 +323,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
           GH_REPO: ${{ github.repository }}
         run: |
+          set -o pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
           ISSUE_NUM=${{ github.event.issue.number }}
 
@@ -322,10 +347,15 @@ jobs:
             # job only routes Done/Canceled → In Progress, so it will leave TBT alone.
             # Without this, pr-merged can miss the link (cross-repo `owner/repo#N` form)
             # and the issue ends up in In Progress instead of parked for review (#262).
-            GUARD_ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 2>&1 | tr -d '\000-\037') || {
-              echo "::warning::Cannot access project board — skipping TBT routing for #$ISSUE_NUM"
+            GUARD_ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 | tr -d '\000-\037') || {
+              echo "::warning::Cannot access project board — skipping TBT routing for #$ISSUE_NUM (gh exit non-zero)"
               GUARD_ITEMS=""
             }
+            if [ -n "$GUARD_ITEMS" ] && ! printf '%s' "$GUARD_ITEMS" | jq empty 2>/dev/null; then
+              echo "::warning::gh returned non-JSON — skipping TBT routing for #$ISSUE_NUM"
+              echo "First 80 chars: $(printf '%s' "$GUARD_ITEMS" | head -c 80)"
+              GUARD_ITEMS=""
+            fi
             if [ -n "$GUARD_ITEMS" ]; then
               GUARD_ITEM_ID=$(echo "$GUARD_ITEMS" | jq -r --argjson n "$ISSUE_NUM" \
                 '.items[] | select(.content.number == $n) | .id')
@@ -353,10 +383,15 @@ jobs:
 
           # --- Move to Done on board ---
           # Strip control chars (U+0000-U+001F) to prevent jq parse failures
-          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 2>&1 | tr -d '\000-\037') || {
-            echo "::warning::Cannot access project board (ensure PROJECT_PAT has repo, project, and read:org scopes)"
+          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 | tr -d '\000-\037') || {
+            echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
             exit 0
           }
+          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
+            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+            exit 0
+          fi
 
           ITEM_ID=$(echo "$ITEMS" | jq -r --argjson n "$ISSUE_NUM" \
             '.items[] | select(.content.number == $n) | .id')
@@ -389,10 +424,19 @@ jobs:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
           GH_REPO: ${{ github.repository }}
         run: |
+          set -o pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
 
           # Get all board items, strip control chars
-          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 2>&1 | tr -d '\000-\037') || exit 0
+          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 | tr -d '\000-\037') || {
+            echo "::warning::Cannot access project board (gh exit non-zero — ensure PROJECT_PAT has repo, project, and read:org scopes)"
+            exit 0
+          }
+          if ! printf '%s' "$ITEMS" | jq empty 2>/dev/null; then
+            echo "::warning::gh returned non-JSON (likely auth, rate-limit, or scope drift)"
+            echo "First 80 chars: $(printf '%s' "$ITEMS" | head -c 80)"
+            exit 0
+          fi
 
           # Find items NOT in Done/Canceled
           ACTIVE_NUMS=$(echo "$ITEMS" | jq -r '


### PR DESCRIPTION
## Summary

Closes #285.

Six `gh project item-list ... 2>&1 | tr -d '\000-\037'` call sites (plus the schedule reconcile that used the bare `|| exit 0` form) silently masked auth/scope/rate-limit errors. With `tr` always exiting 0, the `||` fallback never fired; gh's stderr got captured into `ITEMS`, and the next `jq` either hard-failed (`Invalid numeric literal at line 1, column 8`, observed on PR #284) or quietly returned empty results (`Reconciliation complete: 0 issues fixed`, observed on the 2026-05-05 08:18 schedule run).

## Fix

Three complementary hardenings per affected `run:` block:

1. **`set -o pipefail`** — non-zero gh exits propagate through the pipe so the `||` fallback fires correctly. Defensive even where the GitHub Actions runner already sets it by default.
2. **Drop `2>&1`** — gh's error messages now land on stderr (visible in CI logs) instead of contaminating `$ITEMS`.
3. **`jq empty` validation** — after every `ITEMS=$(...)` capture, validate the payload is JSON. On failure: emit a `::warning::` plus the first 80 chars of `$ITEMS` so the operator can identify the cause without grepping logs.

Sites covered (all seven, not the six listed in the issue body — the issue's prose calls out `board-reconcile` as a failure mode but the line list omits it):

- pr-opened
- pr-merged
- issue-assigned
- issue-reopened
- issue-closed (both `GUARD_ITEMS` inner block and the move-to-Done `ITEMS`)
- board-reconcile (line 395, was using the silent `|| exit 0` form)

## Test plan

- [ ] Trigger a known-bad scenario (temporarily underscoped `PROJECT_PAT`) — workflow emits a clear `::warning::` with the first 80 chars of gh's error and exits 0, instead of `jq: parse error: Invalid numeric literal at line 1, column 8`.
- [ ] PR opened with a `Closes #N` body — linked issue moves Todo → In Progress within ~30s.
- [ ] PR merged with a `Closes #N` body — linked issue moves to Done.
- [ ] Issue lifecycle (assigned, opened, reopened, closed-with-criteria) routes correctly on the board.
- [ ] Schedule run (or `workflow_dispatch`) executes board-reconcile; reports a non-zero `$FIXED` count when the board has actual drift.

## Notes

- `bash -n` checked all 7 extracted run-blocks — clean.
- YAML parses (Ruby `YAML.load_file`).
- 22/24 test suites pass; the 2 failing suites (07 — agent-permissions, 21 — snapshot-regression) fail identically on `main` (verified by stashing). Suite 21's drift is from yesterday's #283/#284 merge changing `validate-bash.sh`; suite 07 is `project-coordinator` missing frontmatter — both pre-existing, out of scope here.