### PR TITLE
fix(cicd): replace per-issue REST loop in board-reconcile with bulk GraphQL (#287)

### DIFF
--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -440,34 +440,57 @@ jobs:
           fi
 
           # Find items NOT in Done/Canceled
-          ACTIVE_NUMS=$(echo "$ITEMS" | jq -r '
+          mapfile -t ACTIVE_NUMS < <(echo "$ITEMS" | jq -r '
             .items[] |
             select(.content.type == "Issue") |
             select(.status != "Done" and .status != "Canceled") |
             .content.number
           ' | sort -n -u)
 
+          # Bulk-fetch issue states via aliased GraphQL — a per-issue REST
+          # loop hits GitHub's secondary rate limit on 80+ sequential calls
+          # and exceeds the 15-min step boundary. Batches of 100 alias
+          # entries per query stay under GitHub's GraphQL node/cost limits
+          # while collapsing N round-trips to ceil(N/100).
+          REPO_OWNER="${GH_REPO%/*}"
+          REPO_NAME="${GH_REPO#*/}"
+          CLOSED_NUMS=""
+          BATCH_SIZE=100
+          TOTAL=${#ACTIVE_NUMS[@]}
+          for ((i=0; i<TOTAL; i+=BATCH_SIZE)); do
+            BATCH=("${ACTIVE_NUMS[@]:i:BATCH_SIZE}")
+            QUERY='query { repository(owner: "'"$REPO_OWNER"'", name: "'"$REPO_NAME"'") {'
+            for N in "${BATCH[@]}"; do
+              QUERY="$QUERY i${N}: issue(number: $N) { state }"
+            done
+            QUERY="$QUERY } }"
+            BATCH_CLOSED=$(gh api graphql -f query="$QUERY" \
+              --jq '.data.repository | to_entries[] | select(.value != null and .value.state == "CLOSED") | (.key | sub("^i"; ""))' \
+              2>/dev/null) || {
+              echo "::warning::Bulk state lookup failed for batch starting at index $i — skipping batch"
+              continue
+            }
+            CLOSED_NUMS="$CLOSED_NUMS $BATCH_CLOSED"
+          done
+
           FIXED=0
-          for NUM in $ACTIVE_NUMS; do
-            STATE=$(gh issue view "$NUM" --repo "$GH_REPO" --json state --jq '.state' 2>/dev/null)
-            if [ "$STATE" = "CLOSED" ]; then
-              ITEM_ID=$(echo "$ITEMS" | jq -r --argjson n "$NUM" \
-                '.items[] | select(.content.number == $n) | .id' | head -1)
-              if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then
-                gh api graphql -f query='mutation {
-                  updateProjectV2ItemFieldValue(input: {
-                    projectId: "'"$PROJECT_ID"'"
-                    itemId: "'"$ITEM_ID"'"
-                    fieldId: "'"$STATUS_FIELD_ID"'"
-                    value: { singleSelectOptionId: "'"$DONE_ID"'" }
-                  }) { projectV2Item { id } }
-                }' --silent || {
-                  echo "::warning::Board mutation failed for #$NUM (check PROJECT_PAT scopes or project permissions)"
-                  continue
-                }
-                echo "Reconciled #$NUM → Done (was closed but board status stale)"
-                FIXED=$((FIXED + 1))
-              fi
+          for NUM in $CLOSED_NUMS; do
+            ITEM_ID=$(echo "$ITEMS" | jq -r --argjson n "$NUM" \
+              '.items[] | select(.content.number == $n) | .id' | head -1)
+            if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then
+              gh api graphql -f query='mutation {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: "'"$PROJECT_ID"'"
+                  itemId: "'"$ITEM_ID"'"
+                  fieldId: "'"$STATUS_FIELD_ID"'"
+                  value: { singleSelectOptionId: "'"$DONE_ID"'" }
+                }) { projectV2Item { id } }
+              }' --silent || {
+                echo "::warning::Board mutation failed for #$NUM (check PROJECT_PAT scopes or project permissions)"
+                continue
+              }
+              echo "Reconciled #$NUM → Done (was closed but board status stale)"
+              FIXED=$((FIXED + 1))
             fi
           done
           echo "Reconciliation complete: $FIXED issues fixed"


### PR DESCRIPTION
## Summary

Closes #287.

`board-reconcile` (daily 06:00 UTC schedule) iterated over active board items doing one `gh issue view <N> --json state` REST call each. On the current 112-active-item board this triggered GitHub's secondary rate limit and the job was cancelled at the 15-min step boundary before reaching the final `Reconciliation complete:` line.

Reproduced today: runs [25424853482 attempt 1](https://github.com/mindcockpit-ai/cognitive-core/actions/runs/25424853482) and attempt-2 (rerun) both `cancelled` at exactly 15 min. Pre-#286 the silent-failure bug masked this as `success: 0 issues fixed` with cryptic jq parse errors; #286's hardening surfaced the cancellation cleanly, which is what enabled this diagnosis.

## Fix

Replace the per-issue REST loop with aliased GraphQL queries batched in groups of 100:

```graphql
query { repository(owner: "...", name: "...") {
  i287: issue(number: 287) { state }
  i286: issue(number: 286) { state }
  ...
} }
```

Then iterate the response once and run the existing single mutation per stale item.

## Performance

| Active items | Old (REST loop) | New (bulk GraphQL) |
|---|---|---|
| 112 (today) | 15 min ⇒ cancelled | **1 second** |
| Round-trips | 112 sequential | 2 (ceil(112/100)) |

Local benchmark output:

```
TOTAL active: 112
  batch 1: 100 aliases
  batch 2: 12 aliases
TOTAL bulk-lookup time: 1s
CLOSED but on board (would be reconciled to Done): 0
```

## Test plan

- [ ] Wait for next 06:00 UTC schedule run (cron `'0 6 * * *'`); workflow has no `workflow_dispatch` registered, so cannot trigger manually.
- [ ] Verify run completes within step budget with conclusion `success`.
- [ ] Verify log contains `Reconciliation complete: N issues fixed`.
- [ ] Verify no regression on the silent-failure hardening from #285 — the `set -euo pipefail` + `jq -e` shape probe + dropped `2>&1` are unchanged in this PR.
- [ ] When a closed-but-stale issue exists on the board, `$FIXED` reports a non-zero count (no test cases of this on the board today; will materialise organically when an issue is closed via GitHub UI without using `/project-board approve`).

## Notes

- 23/24 test suites pass on this branch. Suite 21 (snapshot-regression) fails identically on `main` due to pre-existing snapshot drift from #283/#284 — out of scope here.
- YAML parses cleanly; all 7 extracted run-blocks pass `bash -n`.
- Comment in code intentionally avoids the "see #287" reference per CLAUDE.md ("don't reference task numbers in code comments — they rot"). The technical explanation stands alone.