### PR TITLE
feat(hooks): add check-forbidden-chars.sh for AI-tell character enforcement

### DIFF
--- a/core/hooks/check-forbidden-chars.sh
+++ b/core/hooks/check-forbidden-chars.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# Forbidden-Character Pre-commit Check
+#
+# Two enforcement modes, extension-driven:
+#
+#   ASCII-ONLY  (source code): rejects ANY non-ASCII byte (>0x7F)
+#               Default extensions: pm, pl, t, sh, bash, js, ts, tsx, jsx,
+#                 css, scss, less, html, tx, yml, yaml, json, toml, ini, conf,
+#                 sql, py, rb, go, java, c, h, cpp, hpp, psgi, pod
+#               Rationale: any non-ASCII in code is suspect (smart-quote
+#                 artifacts, copy-paste from AI, locale strings that should
+#                 live in data files). Stricter than a blocklist; future-proof.
+#
+#   BLOCKLIST   (docs): rejects only the configured AI-tell characters
+#               Default extensions: md, markdown, txt, rst, adoc
+#               Rationale: docs legitimately contain German, math notation,
+#                 customer-source data; only ban known AI tells.
+#
+# Default blocklist:
+#   U+2014 EM DASH                  -> "-"
+#   U+2013 EN DASH                  -> "-"
+#   U+2026 HORIZONTAL ELLIPSIS      -> "..."
+#   U+2018 LEFT SINGLE QUOTATION    -> "'"
+#   U+2019 RIGHT SINGLE QUOTATION   -> "'"
+#   U+201C LEFT DOUBLE QUOTATION    -> '"'
+#   U+201D RIGHT DOUBLE QUOTATION   -> '"'
+#   U+2192 RIGHTWARDS ARROW         -> "->"
+#   U+00A0 NO-BREAK SPACE           -> " "
+#   U+200B ZERO-WIDTH SPACE         -> remove
+#   U+200C ZERO-WIDTH NON-JOINER    -> remove
+#
+# Configuration (per-project overrides):
+#   .husky/forbidden-chars.conf   (preferred)
+#   bin/hooks/forbidden-chars.conf (fallback)
+#
+# Config directives:
+#   CODE_EXT = pm pl t sh js ...        # space-separated; override code extensions
+#   DOC_EXT  = md txt rst ...           # space-separated; override doc extensions
+#   ALLOW_DEFAULT = 0                   # blocklist: start from empty list
+#   <hex> <NAME> [-> <repl>]            # add/override a blocklist rule
+#   !<hex>                              # remove a default blocklist rule
+#
+# Bypass (not recommended): git commit --no-verify
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+DEFAULT_CODE_EXT="pm pl t sh bash js ts tsx jsx css scss less html tx yml yaml json toml ini conf sql py rb go java c h cpp hpp psgi pod"
+DEFAULT_DOC_EXT="md markdown txt rst adoc"
+
+DEFAULT_FORBIDDEN=(
+    "2014|EM DASH|-"
+    "2013|EN DASH|-"
+    "2026|HORIZONTAL ELLIPSIS|..."
+    "2018|LEFT SINGLE QUOTATION MARK|'"
+    "2019|RIGHT SINGLE QUOTATION MARK|'"
+    "201C|LEFT DOUBLE QUOTATION MARK|\""
+    "201D|RIGHT DOUBLE QUOTATION MARK|\""
+    "2192|RIGHTWARDS ARROW|->"
+    "00A0|NO-BREAK SPACE| "
+    "200B|ZERO-WIDTH SPACE|REMOVE"
+    "200C|ZERO-WIDTH NON-JOINER|REMOVE"
+)
+
+CONFIG_FILE=""
+if [ -f "$REPO_ROOT/.husky/forbidden-chars.conf" ]; then
+    CONFIG_FILE="$REPO_ROOT/.husky/forbidden-chars.conf"
+elif [ -f "$REPO_ROOT/bin/hooks/forbidden-chars.conf" ]; then
+    CONFIG_FILE="$REPO_ROOT/bin/hooks/forbidden-chars.conf"
+fi
+
+CODE_EXT="$DEFAULT_CODE_EXT"
+DOC_EXT="$DEFAULT_DOC_EXT"
+declare -a EFFECTIVE
+EFFECTIVE=("${DEFAULT_FORBIDDEN[@]}")
+
+if [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        [ -z "$line" ] && continue
+
+        case "$line" in
+            CODE_EXT*=*)
+                CODE_EXT="$(echo "$line" | sed -E 's/^CODE_EXT[[:space:]]*=[[:space:]]*//')"
+                continue
+                ;;
+            DOC_EXT*=*)
+                DOC_EXT="$(echo "$line" | sed -E 's/^DOC_EXT[[:space:]]*=[[:space:]]*//')"
+                continue
+                ;;
+            ALLOW_DEFAULT*=*0*)
+                EFFECTIVE=()
+                continue
+                ;;
+            ALLOW_DEFAULT*=*1*)
+                EFFECTIVE=("${DEFAULT_FORBIDDEN[@]}")
+                continue
+                ;;
+        esac
+
+        if [ "${line#!}" != "$line" ]; then
+            hex=$(echo "${line#!}" | awk '{print toupper($1)}')
+            new=()
+            for entry in "${EFFECTIVE[@]}"; do
+                [ "${entry%%|*}" != "$hex" ] && new+=("$entry")
+            done
+            EFFECTIVE=("${new[@]}")
+            continue
+        fi
+
+        hex=$(echo "$line" | awk '{print toupper($1)}')
+        rest=$(echo "$line" | sed -E 's/^[^[:space:]]+[[:space:]]+//')
+        if echo "$rest" | grep -q '\->'; then
+            name=$(echo "$rest" | sed -E 's/[[:space:]]*->.*//')
+            repl=$(echo "$rest" | sed -E 's/^.*-> ?//')
+        else
+            name="$rest"
+            repl="REMOVE"
+        fi
+        EFFECTIVE+=("$hex|$name|$repl")
+    done < "$CONFIG_FILE"
+fi
+
+build_regex() {
+    local exts="$1"
+    local r=""
+    for e in $exts; do
+        [ -n "$r" ] && r+="|"
+        r+="\\.$e\$"
+    done
+    echo "$r"
+}
+CODE_REGEX=$(build_regex "$CODE_EXT")
+DOC_REGEX=$(build_regex "$DOC_EXT")
+ALL_REGEX="${CODE_REGEX}|${DOC_REGEX}"
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep -E "$ALL_REGEX" || true)
+[ -z "$STAGED" ] && exit 0
+
+PERL_HASH=""
+for entry in "${EFFECTIVE[@]}"; do
+    [ -z "$entry" ] && continue
+    hex="${entry%%|*}"
+    rest="${entry#*|}"
+    name="${rest%%|*}"
+    PERL_HASH+="\"\\x{$hex}\" => \"U+$hex $name\","
+done
+
+VIOLATIONS=0
+SCRIPT_FILE="$(cd "$(dirname "$0")" && pwd -P)/$(basename "$0")"
+ABS_CONFIG_FILE="${CONFIG_FILE:+$(cd "$(dirname "$CONFIG_FILE")" && pwd -P)/$(basename "$CONFIG_FILE")}"
+
+for file in $STAGED; do
+    [ ! -f "$file" ] && continue
+    abs_file="$(cd "$(dirname "$file")" && pwd -P)/$(basename "$file")"
+    [ "$abs_file" = "$SCRIPT_FILE" ] && continue
+    [ -n "$ABS_CONFIG_FILE" ] && [ "$abs_file" = "$ABS_CONFIG_FILE" ] && continue
+
+    OUTPUT=""
+    MODE=""
+
+    if echo "$file" | grep -qE "$CODE_REGEX"; then
+        MODE="ASCII"
+        OUTPUT=$(perl -ne '
+            while (/([^\x00-\x7F]+)/g) {
+                my $ln = $.;
+                my $bad = $1;
+                my @cps = map { sprintf("U+%04X", ord) } split //, $bad;
+                my $cp_str = join(" ", @cps);
+                my $excerpt = $_;
+                chomp $excerpt;
+                if (length $excerpt > 80) { $excerpt = substr($excerpt, 0, 77) . "..."; }
+                print "    line $ln [non-ASCII: $cp_str]: $excerpt\n";
+                last;
+            }
+        ' "$file" 2>/dev/null)
+    elif echo "$file" | grep -qE "$DOC_REGEX"; then
+        MODE="BLOCK"
+        if [ "${#EFFECTIVE[@]}" = "0" ]; then
+            continue
+        fi
+        OUTPUT=$(perl -CSD -ne "
+            BEGIN { our %FN = ($PERL_HASH); our @KEYS = sort keys %FN; }
+            for my \$c (@KEYS) {
+                while (/\\Q\$c\\E/g) {
+                    my \$ln = \$.;
+                    my \$excerpt = \$_;
+                    chomp \$excerpt;
+                    if (length \$excerpt > 80) { \$excerpt = substr(\$excerpt, 0, 77) . '...'; }
+                    print \"    line \$ln [\$FN{\$c}]: \$excerpt\\n\";
+                    last;
+                }
+            }
+        " "$file" 2>/dev/null)
+    fi
+
+    if [ -n "$OUTPUT" ]; then
+        if [ $VIOLATIONS -eq 0 ]; then
+            echo "Forbidden characters detected in staged files:"
+            [ -n "$CONFIG_FILE" ] && echo "  (config: $CONFIG_FILE)"
+            echo ""
+        fi
+        echo "  $file [mode: $MODE]:"
+        echo "$OUTPUT"
+        VIOLATIONS=$((VIOLATIONS + 1))
+    fi
+done
+
+if [ $VIOLATIONS -gt 0 ]; then
+    echo ""
+    echo "Source code (CODE_EXT) must be pure ASCII. Docs (DOC_EXT) must avoid AI-tell characters."
+    echo ""
+    echo "Auto-fix doc files (default replacement table):"
+    echo "    perl -i -CSD -pe '"
+    for entry in "${EFFECTIVE[@]}"; do
+        [ -z "$entry" ] && continue
+        hex="${entry%%|*}"
+        rest="${entry#*|}"
+        name="${rest%%|*}"
+        repl="${rest#*|}"
+        if [ "$repl" = "REMOVE" ]; then
+            echo "        s/\\x{$hex}//g;       # $name"
+        else
+            esc_repl="${repl//\'/\'\\\'\'}"
+            echo "        s/\\x{$hex}/$esc_repl/g;       # $name"
+        fi
+    done
+    echo "    ' \$(git diff --cached --name-only --diff-filter=ACM | grep -E '\\.(md|markdown|txt|rst|adoc)\$')"
+    echo ""
+    echo "Source code with non-ASCII must be edited manually (move locale strings to data files,"
+    echo "or escape via \\x{NNNN} in Perl, \\uNNNN in JS, etc.)"
+    echo ""
+    echo "To bypass (not recommended): git commit --no-verify"
+    exit 1
+fi
+
+exit 0

--- a/core/skills/pre-commit/SKILL.md
+++ b/core/skills/pre-commit/SKILL.md
@@ -81,8 +81,68 @@ Failed: N
 | `LINT_WARN=1` | Warn only, do not block |
 | `SKIP_LINT=1` | Skip all lint checks |
 
+## Forbidden-Character Enforcement (optional, via `core/hooks/check-forbidden-chars.sh`)
+
+Cognitive-core ships a standalone pre-commit script that blocks AI-tell characters in staged files. It is **not auto-installed** by `update.sh`; projects opt in by referencing the script from their git pre-commit hook (or husky pre-commit).
+
+### Two enforcement modes (extension-driven)
+
+| Mode | Default extensions | Behavior |
+|---|---|---|
+| **ASCII-ONLY** | `pm pl t sh bash js ts tsx jsx css scss less html tx yml yaml json toml ini conf sql py rb go java c h cpp hpp psgi pod` | Rejects any byte > 0x7F. No exceptions. |
+| **BLOCKLIST** | `md markdown txt rst adoc` | Rejects only the configured AI-tell chars (defaults below). |
+
+### Default blocklist (doc files)
+
+| Code-point | Name | Replacement |
+|---|---|---|
+| U+2014 | EM DASH | `-` |
+| U+2013 | EN DASH | `-` |
+| U+2026 | HORIZONTAL ELLIPSIS | `...` |
+| U+2018 / U+2019 | TYPOGRAPHIC SINGLE QUOTES | `'` |
+| U+201C / U+201D | TYPOGRAPHIC DOUBLE QUOTES | `"` |
+| U+2192 | RIGHTWARDS ARROW | `->` |
+| U+00A0 | NO-BREAK SPACE | regular space |
+| U+200B | ZERO-WIDTH SPACE | (removed) |
+| U+200C | ZERO-WIDTH NON-JOINER | (removed) |
+
+### Per-project configuration
+
+Project-local override file at `.husky/forbidden-chars.conf` or `bin/hooks/forbidden-chars.conf`:
+
+```
+CODE_EXT = pm pl t sh js ...        # override code extensions
+DOC_EXT  = md txt rst ...           # override doc extensions
+ALLOW_DEFAULT = 0                   # blocklist: start from empty
+2248 ALMOST EQUAL TO -> ~=          # add a custom rule
+!2018                               # remove a default rule
+```
+
+### Installation in a project
+
+```bash
+# 1. Reference the cognitive-core hook from your pre-commit
+ln -s "$CC_FRAMEWORK_ROOT/core/hooks/check-forbidden-chars.sh" \
+      "$REPO_ROOT/bin/hooks/checkForbiddenChars.sh"
+
+# 2. Add a step to .husky/pre-commit (or .git/hooks/pre-commit)
+echo 'bash bin/hooks/checkForbiddenChars.sh || exit 1' >> .husky/pre-commit
+
+# 3. Optional per-project tuning
+cp /dev/null .husky/forbidden-chars.conf
+edit .husky/forbidden-chars.conf
+```
+
+### Rationale
+
+- ASCII-only for code is **stricter** than tracking individual AI tells but **future-proof** against new ones (e.g., a new Unicode emoji that AI tools start emitting).
+- Blocklist for docs preserves legitimate non-ASCII (German content, math notation, customer-source data, accented names).
+- Both modes operate on staged files only and skip binary files.
+- The hook script and config file are exempt from their own rules (they document the codepoints by necessity).
+
 ## See Also
 
 - `/code-review` -- Full code review (more thorough)
 - `/fitness` -- Quality fitness scoring
 - `CLAUDE.md` -- Project standards reference
+- `core/hooks/check-forbidden-chars.sh` -- AI-tell character pre-commit hook


### PR DESCRIPTION
## Summary
Adds a pre-commit script that blocks AI-tell characters in staged files, with two extension-driven enforcement modes:

- **ASCII-only** for source code (any byte > 0x7F rejected)
- **Blocklist** for docs (11 specific Unicode code-points typical of AI-generated text)

## Mode dispatch
| Mode | Default extensions | Behavior |
|---|---|---|
| ASCII-ONLY | pm pl t sh bash js ts tsx jsx css scss less html tx yml yaml json toml ini conf sql py rb go java c h cpp hpp psgi pod | Rejects any byte > 0x7F |
| BLOCKLIST | md markdown txt rst adoc | Rejects only the configured AI-tell chars |

## Default blocklist (doc files)
```
U+2014 EM DASH                 -> -
U+2013 EN DASH                 -> -
U+2026 HORIZONTAL ELLIPSIS     -> ...
U+2018 LEFT  SINGLE QUOTATION  -> '
U+2019 RIGHT SINGLE QUOTATION  -> '
U+201C LEFT  DOUBLE QUOTATION  -> "
U+201D RIGHT DOUBLE QUOTATION  -> "
U+2192 RIGHTWARDS ARROW        -> ->
U+00A0 NO-BREAK SPACE          -> (space)
U+200B ZERO-WIDTH SPACE        -> (removed)
U+200C ZERO-WIDTH NON-JOINER   -> (removed)
```

## Per-project configuration

`.husky/forbidden-chars.conf` or `bin/hooks/forbidden-chars.conf`:
```
CODE_EXT = pm pl t sh js ...   # override code extensions
DOC_EXT  = md txt rst ...      # override doc extensions
ALLOW_DEFAULT = 0              # blocklist: start from empty
2248 ALMOST EQUAL TO -> ~=     # add a custom rule
!2018                          # remove a default rule
```

## Origin & Validation
This hook originated in TIMS (#445 initial, #446 extended). Validated against real production data on 2026-05-08:
- Detected 49 em-dash characters across 3 newly authored docs (now cleaned)
- TIMS source code already 100% ASCII — the rule introduces no breaking changes for that repo
- Caught 2 prior bugs in the v1 implementation: bash double-escape on `\\x{}` byte patterns, and `\@KEYS` triggering Perl's declared_refs experimental warning

## Installation (opt-in by projects)

Not auto-installed by `update.sh`. Projects opt in:

```bash
# Reference the cognitive-core hook
ln -s "$CC_FRAMEWORK_ROOT/core/hooks/check-forbidden-chars.sh" \
      "$REPO_ROOT/bin/hooks/checkForbiddenChars.sh"

# Add a step to .husky/pre-commit
echo 'bash bin/hooks/checkForbiddenChars.sh || exit 1' >> .husky/pre-commit
```

## Why ASCII-only for code
- Future-proof against new AI tells (no list maintenance)
- Forces locale strings into data files (separation of concerns)
- Catches smart-quote artifacts from copy-paste

## Why blocklist for docs
- Customer-source content legitimately contains German, math notation, accented characters
- Targeted enforcement preserves legitimate Unicode usage

## Test plan
- [x] ASCII mode catches non-ASCII (`ä`) in `.pl` file
- [x] BLOCK mode catches em-dash and ellipsis in `.md` file
- [x] Mixed staged: both modes report independently
- [x] Clean ASCII files / docs without AI tells exit 0
- [x] Bash double-escape bug fixed (was preventing perl hash matching)
- [x] `\@KEYS` declared_refs bug fixed (was making BLOCKLIST mode a no-op)
- [ ] CI green