### PR TITLE
docs(release): add Unreleased section for check-forbidden-chars.sh (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `core/git-hooks/check-forbidden-chars.sh` — opt-in pre-commit hook that blocks AI-tell characters (em-dash, smart quotes, zero-width spaces, etc.) in staged files. Two enforcement modes: ASCII-only for source code, configurable blocklist for docs. Not auto-installed by `update.sh` — see [`core/skills/pre-commit/SKILL.md`](core/skills/pre-commit/SKILL.md) for opt-in instructions. ([#291](https://github.com/mindcockpit-ai/cognitive-core/pull/291))
+
 ## [1.5.0](https://github.com/mindcockpit-ai/cognitive-core/compare/v1.4.1...v1.5.0) (2026-04-14)
 
 


### PR DESCRIPTION
Closes #296

## Summary

Adds an explicit `## [Unreleased]` section above the v1.5.0 heading in `CHANGELOG.md` documenting the AI-tell character pre-commit hook delivered by PR #291 (relocated to `core/git-hooks/` in PR #298).

**Wording**:
- Names the new script and its purpose (AI-tell character enforcement)
- Notes the **opt-in** nature (not installed by `update.sh`)
- Links to `core/skills/pre-commit/SKILL.md` for install instructions
- References PR #291 for full design

## Why `[Unreleased]` rather than appending under v1.5.0

`CHANGELOG.md` is release-please-managed (commit-based regenerator). Using a dedicated `[Unreleased]` section:
- Keeps the manual entry stable through future automated regenerations
- Conventional Keep-a-Changelog pattern, well-precedented
- release-please will fold the `[Unreleased]` content into the next version section automatically

## Verification

- `bash tests/run-all.sh`: 24/25 suites pass. Suite 21 (`snapshot-regression`) fails on a pre-existing `validate-bash.sh` MD5 baseline drift from #283/#284 (tracked in MEMORY.md as a known regression to be filed as a separate chore). Unrelated to CHANGELOG-only changes.
- Path `core/git-hooks/check-forbidden-chars.sh` matches the canonical location settled by mindcockpit-ai/cognitive-core#293 (merged in #298).
- Link targets verified:
  - `core/skills/pre-commit/SKILL.md` exists
  - `core/git-hooks/check-forbidden-chars.sh` exists
  - PR #291 link resolves

## Acceptance Criteria (from #296)

- [x] `## [Unreleased]` section added above v1.5.0 heading
- [x] Entry uses canonical path `core/git-hooks/check-forbidden-chars.sh`
- [x] Wording references opt-in nature
- [x] Link to `core/skills/pre-commit/SKILL.md`
- [x] Reference to PR #291

## Test plan

- [x] Manual diff inspection (6 added lines, no other changes)
- [x] Full test suite run (24/25 pass; 1 pre-existing drift unrelated)
- [ ] CI green (matrix: macOS + Ubuntu)
- [ ] Reviewer agrees wording is accurate and complete