### PR TITLE
refactor(hooks): set -e alignment + Perl trust-boundary doc (closes #297)

### DIFF
--- a/core/git-hooks/check-forbidden-chars.sh
+++ b/core/git-hooks/check-forbidden-chars.sh
@@ -42,8 +42,25 @@
 #   !<hex>                              # remove a default blocklist rule
 #
 # Bypass (not recommended): git commit --no-verify
+#
+# Trust boundary
+# --------------
+# The per-repo config file (.husky/forbidden-chars.conf or
+# bin/hooks/forbidden-chars.conf) is parsed line-by-line and the resulting
+# codepoint/name pairs are interpolated verbatim into an inline Perl
+# `BEGIN { our %FN = (...) }` block (see PERL_HASH below). A hostile config
+# (e.g., `2014" => "x"; system("..."); my $f = "`) could inject arbitrary
+# Perl code that runs with the user's commit privileges.
+#
+# This is **acceptable** under the same trust assumption as `.gitignore`,
+# `.editorconfig`, or any other per-repo config: a compromised repo's local
+# config is out of scope for this hook. Mitigation: configs are typically
+# committed to the repo and reviewed alongside other code changes.
+#
+# See `core/skills/pre-commit/SKILL.md` § "Security model" for the
+# adopter-facing version of this note.
 
-set -uo pipefail
+set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
@@ -172,6 +189,9 @@ while IFS= read -r file; do
 
     if echo "$file" | grep -qE "$CODE_REGEX"; then
         MODE="ASCII"
+        # `|| true`: under `set -e`, a failing perl (e.g., file disappeared
+        # between the existence check and the read) would abort the script.
+        # An empty capture is the natural "no violation" signal here.
         OUTPUT=$(perl -ne '
             while (/([^\x00-\x7F]+)/g) {
                 my $ln = $.;
@@ -184,12 +204,13 @@ while IFS= read -r file; do
                 print "    line $ln [non-ASCII: $cp_str]: $excerpt\n";
                 last;
             }
-        ' "$file" 2>/dev/null)
+        ' "$file" 2>/dev/null || true)
     elif echo "$file" | grep -qE "$DOC_REGEX"; then
         MODE="BLOCK"
         if [ "${#EFFECTIVE[@]}" = "0" ]; then
             continue
         fi
+        # `|| true`: see ASCII-mode comment above. Identical rationale.
         OUTPUT=$(perl -CSD -ne "
             BEGIN { our %FN = ($PERL_HASH); our @KEYS = sort keys %FN; }
             for my \$c (@KEYS) {
@@ -202,7 +223,7 @@ while IFS= read -r file; do
                     last;
                 }
             }
-        " "$file" 2>/dev/null)
+        " "$file" 2>/dev/null || true)
     fi
 
     if [ -n "$OUTPUT" ]; then

--- a/core/skills/pre-commit/SKILL.md
+++ b/core/skills/pre-commit/SKILL.md
@@ -140,6 +140,23 @@ edit .husky/forbidden-chars.conf
 - Both modes operate on staged files only and skip binary files.
 - The hook script and config file are exempt from their own rules (they document the codepoints by necessity).
 
+### Security model
+
+The per-repo config file (`.husky/forbidden-chars.conf` or `bin/hooks/forbidden-chars.conf`) is parsed line-by-line, and the resulting `<codepoint>|<name>` pairs are interpolated **verbatim** into an inline Perl `BEGIN { our %FN = (...) }` block. A hostile config can therefore inject arbitrary Perl code that runs with the user's commit privileges:
+
+```
+# Malicious .husky/forbidden-chars.conf entry (illustrative)
+2014" => "x"; system("..."); my $f = "
+```
+
+This is **acceptable** under the same trust assumption as `.gitignore`, `.editorconfig`, `.gitattributes`, and other per-repo config files: a compromised repo's local config is out of scope for this hook. Mitigation:
+
+- Configs are typically committed to the repo and reviewed alongside other code changes (PR review catches malicious edits).
+- Pre-commit hooks only run on machines where the user has already cloned and trusted the repo.
+- Adopters who need stronger isolation should run hooks inside a sandboxed environment (e.g., container, VM) or use a pre-commit framework with its own sandboxing.
+
+The script header (`core/git-hooks/check-forbidden-chars.sh`) carries the same note for reviewers reading the code.
+
 ## See Also
 
 - `/code-review` -- Full code review (more thorough)


### PR DESCRIPTION
Closes #297

## Summary

Two-part polish on `core/git-hooks/check-forbidden-chars.sh` (post-merge follow-ups from PR #291 review at https://github.com/mindcockpit-ai/cognitive-core/pull/291#issuecomment-4408508626):

### A2 — `set -e` alignment

- `set -uo pipefail` -> `set -euo pipefail` per `CLAUDE.md` § Code Standards.
- Added explicit `|| true` to the two `OUTPUT=$(perl ... 2>/dev/null)` substitutions (ASCII-mode and BLOCK-mode). Under `set -e`, a failing perl (e.g., file disappears between the `[ -f ]` guard and the read) would otherwise abort the script; an empty capture is the natural "no violation" signal here.
- The `[ test ] && action` idiom remains safe under `set -e` because bash treats a top-level `&&` list as a conditional — verified empirically.

### S1 — Perl-code-injection trust boundary doc

- **Script header** carries a "Trust boundary" block-comment for code reviewers.
- **`core/skills/pre-commit/SKILL.md`** adds a "Security model" subsection under "Forbidden-Character Enforcement" for adopters.

Both notes state the same trust model: a per-repo config (`.husky/forbidden-chars.conf` / `bin/hooks/forbidden-chars.conf`) can inject Perl code into the inline `BEGIN { our %FN = (...) }` block, but this is acceptable under the same trust assumption as `.gitignore`, `.editorconfig`, etc. — a compromised repo's local config is out of scope for this hook.

## Acceptance Criteria (from #297)

- [x] Script uses `set -euo pipefail` with explicit `\|\| true` where needed
- [x] ShellCheck remains clean (`/opt/homebrew/bin/shellcheck` -> 0 issues)
- [x] Header comment documents the trust boundary for the config-file -> Perl-BEGIN-block path
- [x] `core/skills/pre-commit/SKILL.md` "Forbidden-Character Enforcement" section adds a "Security model" subsection
- [x] No behavior change for valid (non-malicious) configs
- [x] Tests still pass (suite 19 = 42/42, including all 11 net-new cases from #294)

## Test plan

- [x] `bash -n core/git-hooks/check-forbidden-chars.sh` -> SYNTAX OK
- [x] `shellcheck core/git-hooks/check-forbidden-chars.sh` -> SHELLCHECK OK
- [x] `bash tests/suites/19-check-forbidden-chars.sh` -> **42 passed, 0 failed, 0 skipped**
- [x] `bash tests/run-all.sh` -> **24/25 suites pass**. Suite 21 (`snapshot-regression`) reports the pre-existing `validate-bash.sh` MD5 drift from #283/#284 — unrelated to these changes (no `validate-bash.sh` content modified).
- [ ] CI: macOS + Ubuntu matrix (will be checked after PR open)

## Related

- Origin PR: #291
- Previous follow-ups in this batch: #298 (closed #293/#294/#295), #299 (closed #296)
- Last item in the #291 follow-up sweep