### PR TITLE
fix(cicd): board-automation handles PRs with no linked issues

### DIFF
--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -60,9 +60,10 @@ jobs:
           ${{ github.event.pull_request.body }}
           PREOF
           )
+          # `|| true` keeps set -e + pipefail from tripping when no `closes #N` keyword is present (empty result is handled below).
           ISSUES=$(echo "$PR_BODY" | \
             grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | \
-            grep -oE '[0-9]+' | sort -u)
+            grep -oE '[0-9]+' | sort -u || true)
 
           if [ -z "$ISSUES" ]; then
             echo "No linked issues found in PR body"
@@ -126,9 +127,10 @@ jobs:
           ${{ github.event.pull_request.body }}
           PREOF
           )
+          # `|| true` keeps set -e + pipefail from tripping when no `closes #N` keyword is present (empty result is handled below).
           ISSUES=$(echo "$PR_BODY" | \
             grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | \
-            grep -oE '[0-9]+' | sort -u)
+            grep -oE '[0-9]+' | sort -u || true)
 
           if [ -z "$ISSUES" ]; then
             echo "No linked issues found in PR body"


### PR DESCRIPTION
## Summary

Both `pr-opened` and `pr-merged` jobs in `.github/workflows/project-board-automation.yml` extract issue numbers from the PR body via a `grep | grep | sort` pipeline. Under `set -euo pipefail`, when the PR body has no `closes #N` / `fixes #N` / `resolves #N` keyword:

1. The first `grep` exits **1** (no match).
2. `pipefail` propagates the failure to the whole pipeline.
3. The command substitution's exit code becomes `1`.
4. `set -e` kills the step **before** the `if [ -z "$ISSUES" ]` safety check runs.

Recent PRs all referenced issues, which masked the bug. PR #301 (README peer-review polish) was the first no-link PR in a while and tripped it — single line `Error: Process completed with exit code 1.` with no diagnostic output.

## Fix

Append `|| true` to each extraction pipeline so a no-match condition yields an empty `ISSUES`, which the existing `if [ -z "$ISSUES" ]; then echo "No linked issues found in PR body"; exit 0; fi` branch already handles correctly.

Sites patched:
- `project-board-automation.yml:65` (`pr-opened` job)
- `project-board-automation.yml:131` (`pr-merged` job)

Single-line comment added at each site explaining the non-obvious requirement.

## Test plan

- [ ] CI passes on this PR (this PR body itself does not reference any issue — if the fix works, the `pr-opened` job will produce "No linked issues found in PR body" and exit 0).
- [ ] Confirm PR #301 can be rerun against the fixed workflow on merge (or simply close cleanly with the failed `pr-opened` job no longer being a regression).