### PR TITLE
fix(hooks): scan markdown for secrets, require BEGIN+END for PEM

### DIFF
--- a/core/hooks/validate-write.sh
+++ b/core/hooks/validate-write.sh
@@ -19,9 +19,14 @@ if [ -z "$FILE_PATH" ]; then
     exit 0
 fi
 
-# Skip test files and documentation (high false-positive rate)
+# Skip test fixtures and templates (high false-positive rate). Markdown is NOT skipped:
+# reports and docs are exactly where a copied-in credential needs to be caught. Skip this
+# hooks directory because the scanner's own regex strings would match themselves.
 case "$FILE_PATH" in
-    *_test.* | *_spec.* | *.test.* | *.spec.* | *.md | *.example | *.template)
+    *_test.* | *_spec.* | *.test.* | *.spec.* | *.example | *.template)
+        exit 0
+        ;;
+    */.claude/hooks/*)
         exit 0
         ;;
 esac
@@ -41,8 +46,9 @@ if grep -qE 'AKIA[0-9A-Z]{16}' "$FILE_PATH" 2>/dev/null; then
     STRUCTURED_DENY="aws"
 fi
 
-# PEM private keys
-if grep -q -e '-----BEGIN.*PRIVATE.*KEY-----' "$FILE_PATH" 2>/dev/null; then
+# PEM private keys - require both BEGIN and END so the pattern itself, quoted in docs, doesn't match
+if grep -q -e '-----BEGIN.*PRIVATE.*KEY-----' "$FILE_PATH" 2>/dev/null \
+   && grep -q -e '-----END.*PRIVATE.*KEY-----' "$FILE_PATH" 2>/dev/null; then
     WARNINGS="${WARNINGS}\n- Private key (PEM format) detected"
     if [ -z "$STRUCTURED_DENY" ]; then
         STRUCTURED_DENY="pem"

--- a/tests/suites/06-security-hooks.sh
+++ b/tests/suites/06-security-hooks.sh
@@ -543,6 +543,7 @@ if [ -f "$VALIDATE_WRITE" ]; then
     pem_file="${test_dir}/key.conf"
     echo '-----BEGIN PRIVATE KEY-----' > "$pem_file"
     echo 'MIIEvgIBADANBg...' >> "$pem_file"
+    echo '-----END PRIVATE KEY-----' >> "$pem_file"
 
     output=$(echo "$(mock_write_json "$pem_file" "")" | \
         CC_PROJECT_DIR="$test_dir" bash "$VALIDATE_WRITE" 2>/dev/null) || true
@@ -562,6 +563,18 @@ if [ -f "$VALIDATE_WRITE" ]; then
         _pass "write: skips test files"
     else
         _fail "write: should skip test files" "$output"
+    fi
+
+    # Markdown is NOT skipped: a secret copied into a report/doc must still be caught
+    md_file="${test_dir}/audit-report.md"
+    echo 'Found credential: AWS_KEY = "AKIAIOSFODNN7EXAMPLE1"' > "$md_file"
+
+    output=$(echo "$(mock_write_json "$md_file" "")" | \
+        CC_PROJECT_DIR="$test_dir" bash "$VALIDATE_WRITE" 2>/dev/null) || true
+    if echo "$output" | grep -qiE "aws|secret|key"; then
+        _pass "write: scans markdown documents for secrets"
+    else
+        _fail "write: should scan markdown for secrets" "$output"
     fi
 
     # Clean file should produce no output


### PR DESCRIPTION
## Problem

`validate-write.sh` skipped `*.md` files in its secret scanner. That means a credential **copied into a report or document** — the classic case being a security audit that writes up the very secret it discovered — was never flagged. Markdown is precisely where re-leaked source credentials need to be caught, not exempted.

A secondary self-match issue: the PEM detector fired on a single `-----BEGIN ... PRIVATE KEY-----` line, so documentation that *quotes the pattern* (e.g. explaining what the scanner looks for) tripped a false positive.

## Changes

- **Remove `*.md` from the skip list** — reports and docs are now scanned.
- **Skip `*/.claude/hooks/*` instead** — the scanner's own regex literals live here and would otherwise match themselves.
- **Require both `BEGIN` and `END` markers for PEM detection** — a real private key always has both; the pattern string quoted in docs no longer self-matches.

## Tests

- Updated the PEM fixture to a realistic key (now includes the `END` marker).
- Added a regression test proving a secret written to a `.md` file is flagged — this is the test that would have caught the original gap.
- `tests/suites/06-security-hooks.sh`: **77 passed, 0 failed**.

> Note: 4 unrelated suites (`07`, `12`, `21`, `25`) fail identically on clean `main` in my local macOS environment (bash 3.2 missing `mapfile`, older-Python `X | None` union, snapshot baselines, missing agent frontmatter). Verified by stashing this change — they are pre-existing and untouched here.

## Scope note

Org-specific detection patterns (internal hostnames, service-account formats, intranet URLs) intentionally stay as downstream local extensions and are **not** part of this PR — they don't belong in the public framework.