### PR TITLE
fix(hooks): make check-forbidden-chars.sh pure ASCII; clarify docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - `core/git-hooks/check-forbidden-chars.sh` — opt-in pre-commit hook that blocks AI-tell characters (em-dash, smart quotes, zero-width spaces, etc.) in staged files. Two enforcement modes: ASCII-only for source code, configurable blocklist for docs. Not auto-installed by `update.sh` — see [`core/skills/pre-commit/SKILL.md`](core/skills/pre-commit/SKILL.md) for opt-in instructions. ([#291](https://github.com/mindcockpit-ai/cognitive-core/pull/291))
 
+### Fixed
+
+- `core/git-hooks/check-forbidden-chars.sh` is now pure ASCII — a stray `§` in a comment would have failed the hook's own ASCII-only check when committed under a project that lints `.sh` in ASCII mode.
+
+### Documentation
+
+- `core/skills/pre-commit/SKILL.md`: document the inline-locale-strings case (put such extensions in `DOC_EXT`/blocklist so accented letters are allowed) and clarify that a single commit is bypassed with `git commit --no-verify` (distinct from the lint hook's `SKIP_LINT`).
+
 ## [1.5.0](https://github.com/mindcockpit-ai/cognitive-core/compare/v1.4.1...v1.5.0) (2026-04-14)
 
 

--- a/core/git-hooks/check-forbidden-chars.sh
+++ b/core/git-hooks/check-forbidden-chars.sh
@@ -57,7 +57,7 @@
 # config is out of scope for this hook. Mitigation: configs are typically
 # committed to the repo and reviewed alongside other code changes.
 #
-# See `core/skills/pre-commit/SKILL.md` § "Security model" for the
+# See `core/skills/pre-commit/SKILL.md` section "Security model" for the
 # adopter-facing version of this note.
 
 set -euo pipefail

--- a/core/skills/pre-commit/SKILL.md
+++ b/core/skills/pre-commit/SKILL.md
@@ -118,6 +118,19 @@ ALLOW_DEFAULT = 0                   # blocklist: start from empty
 !2018                               # remove a default rule
 ```
 
+### Working with inline locale strings
+
+Source files that legitimately contain non-ASCII (e.g. UI locale strings inline
+in a `translations.ts`) are rejected by **ASCII-only** mode. Put those extensions
+in `DOC_EXT` (blocklist) rather than `CODE_EXT`, so AI-tell characters are still
+banned while accented letters (German, Slovak, etc.) are allowed.
+
+### Bypassing a single commit
+
+The hook blocks by exiting non-zero. To let one commit through — e.g. when
+committing vendored files that legitimately contain em-dashes — use
+`git commit --no-verify`. This is separate from the lint hook's `SKIP_LINT`.
+
 ### Installation in a project
 
 ```bash


### PR DESCRIPTION
Two small fixes found while adopting the forbidden-character guard (#291) in a downstream project.

## Fix
The guard script contains a `§` (U+00A7) in a comment (line 60). Since the default `CODE_EXT` includes `sh`, the guard would **fail its own ASCII-only check** if committed under a project that lints shell scripts. Replaced with `section`.

## Docs (`pre-commit/SKILL.md`)
- Document the **inline-locale-strings** case: source files with legitimate non-ASCII (e.g. Slovak in `translations.ts`) must use `DOC_EXT`/blocklist, not `CODE_EXT`/ASCII-only.
- Clarify the **bypass** is `git commit --no-verify` (distinct from the lint hook's `SKIP_LINT`).