### PR TITLE
feat(hooks): EXCLUDE path-prefix directive for check-forbidden-chars (re-land)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - `core/git-hooks/check-forbidden-chars.sh` — opt-in pre-commit hook that blocks AI-tell characters (em-dash, smart quotes, zero-width spaces, etc.) in staged files. Two enforcement modes: ASCII-only for source code, configurable blocklist for docs. Not auto-installed by `update.sh` — see [`core/skills/pre-commit/SKILL.md`](core/skills/pre-commit/SKILL.md) for opt-in instructions. ([#291](https://github.com/mindcockpit-ai/cognitive-core/pull/291))
 
+- `core/git-hooks/check-forbidden-chars.sh`: optional `EXCLUDE` config directive — space-separated path prefixes to skip (e.g. vendored/framework directories that legitimately contain AI-tell characters in comments).
+
 ### Fixed
 
 - `core/git-hooks/check-forbidden-chars.sh` is now pure ASCII — a stray `§` in a comment would have failed the hook's own ASCII-only check when committed under a project that lints `.sh` in ASCII mode.

--- a/core/git-hooks/check-forbidden-chars.sh
+++ b/core/git-hooks/check-forbidden-chars.sh
@@ -37,6 +37,7 @@
 # Config directives:
 #   CODE_EXT = pm pl t sh js ...        # space-separated; override code extensions
 #   DOC_EXT  = md txt rst ...           # space-separated; override doc extensions
+#   EXCLUDE  = .claude/ vendor/         # space-separated path prefixes to skip
 #   ALLOW_DEFAULT = 0                   # blocklist: start from empty list
 #   <hex> <NAME> [-> <repl>]            # add/override a blocklist rule
 #   !<hex>                              # remove a default blocklist rule
@@ -90,6 +91,7 @@ fi
 
 CODE_EXT="$DEFAULT_CODE_EXT"
 DOC_EXT="$DEFAULT_DOC_EXT"
+EXCLUDE=""
 declare -a EFFECTIVE
 EFFECTIVE=("${DEFAULT_FORBIDDEN[@]}")
 
@@ -111,6 +113,10 @@ if [ -n "$CONFIG_FILE" ] && [ -f "$CONFIG_FILE" ]; then
                 ;;
             DOC_EXT*=*)
                 DOC_EXT="$(echo "$line" | sed -E 's/^DOC_EXT[[:space:]]*=[[:space:]]*//')"
+                continue
+                ;;
+            EXCLUDE*=*)
+                EXCLUDE="$(echo "$line" | sed -E 's/^EXCLUDE[[:space:]]*=[[:space:]]*//')"
                 continue
                 ;;
             ALLOW_DEFAULT*=*0*)
@@ -161,6 +167,20 @@ ALL_REGEX="${CODE_REGEX}|${DOC_REGEX}"
 
 STAGED=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep -E "$ALL_REGEX" || true)
 [ -z "$STAGED" ] && exit 0
+
+# Optional path exclusions: drop staged files under any space-separated path
+# prefix listed in EXCLUDE (e.g. vendored/framework dirs that legitimately
+# contain AI-tell characters in comments).
+if [ -n "$EXCLUDE" ]; then
+    EXCLUDE_REGEX=""
+    for p in $EXCLUDE; do
+        esc=$(printf '%s' "$p" | sed -E 's/[][(){}.^$*+?|\\]/\\&/g')
+        [ -n "$EXCLUDE_REGEX" ] && EXCLUDE_REGEX="$EXCLUDE_REGEX|"
+        EXCLUDE_REGEX="$EXCLUDE_REGEX^$esc"
+    done
+    STAGED=$(printf '%s\n' "$STAGED" | grep -vE "$EXCLUDE_REGEX" || true)
+    [ -z "$STAGED" ] && exit 0
+fi
 
 PERL_HASH=""
 for entry in ${EFFECTIVE[@]+"${EFFECTIVE[@]}"}; do

--- a/core/skills/pre-commit/SKILL.md
+++ b/core/skills/pre-commit/SKILL.md
@@ -113,10 +113,15 @@ Project-local override file at `.husky/forbidden-chars.conf` or `bin/hooks/forbi
 ```
 CODE_EXT = pm pl t sh js ...        # override code extensions
 DOC_EXT  = md txt rst ...           # override doc extensions
+EXCLUDE  = .claude/ vendor/         # skip files under these path prefixes
 ALLOW_DEFAULT = 0                   # blocklist: start from empty
 2248 ALMOST EQUAL TO -> ~=          # add a custom rule
 !2018                               # remove a default rule
 ```
+
+`EXCLUDE` skips files under the given space-separated path prefixes — useful for
+vendored or framework directories (e.g. `.claude/`) whose comments legitimately
+contain AI-tell characters; without it, committing those files trips the guard.
 
 ### Working with inline locale strings
 


### PR DESCRIPTION
Re-lands the `EXCLUDE` directive. The original #307 was stacked on #306's branch and, when #306 squash-merged to `main`, #307's change never reached `main` (it merged into the deleted feature branch). This PR cherry-picks the same commit directly onto `main`.

## What
New `EXCLUDE` config directive: space-separated path prefixes to skip (e.g. `EXCLUDE = .claude/ vendor/`) so adopters can exclude vendored/framework dirs whose comments legitimately contain em-dashes. Post-collection `grep -vE` with regex-escaped, anchored prefixes. Docs + CHANGELOG included. Tested (non-excluded em-dash blocked; excluded paths skipped).