### PR TITLE
fix(hooks): WebFetch 'don't ask again' never persists — repair session cache key (#310)

### DIFF
--- a/core/hooks/_lib.sh
+++ b/core/hooks/_lib.sh
@@ -297,10 +297,16 @@ _cc_guard_run() {
 
 # Session-scoped domain cache for hooks (e.g., validate-fetch "don't ask again")
 # Cache file is scoped to the Claude session to prevent cross-session leakage.
-# Uses CLAUDE_SESSION_KEY (set by Claude Code) or falls back to parent PID.
+# Session key resolution order:
+#   1. CLAUDE_SESSION_KEY     — explicit override (used by tests)
+#   2. CLAUDE_CODE_SESSION_ID — the real session id Claude Code exports; stable
+#      across every hook invocation AND subagent in a session (incl. workflows)
+#   3. ppid_$PPID            — fallback to the parent (the persistent Claude Code
+#      process), NOT $$ which is each hook's own one-shot PID and never matches
+#      between a PostToolUse write and the next PreToolUse read.
 _cc_session_cache_file() {
     local namespace="${1:-domains}"
-    local session_key="${CLAUDE_SESSION_KEY:-ppid_$$}"
+    local session_key="${CLAUDE_SESSION_KEY:-${CLAUDE_CODE_SESSION_ID:-ppid_$PPID}}"
     local cache_dir="${TMPDIR:-/tmp}"
     echo "${cache_dir}/cc-session-${namespace}-${session_key}"
 }

--- a/tests/suites/06-security-hooks.sh
+++ b/tests/suites/06-security-hooks.sh
@@ -500,6 +500,37 @@ if [ -f "$VALIDATE_FETCH" ]; then
         _skip "post-fetch-cache.sh not found"
     fi
 
+    # Regression (#119): real-world flow with NO CLAUDE_SESSION_KEY set.
+    # Production exports CLAUDE_CODE_SESSION_ID, not CLAUDE_SESSION_KEY. Each hook
+    # is its own process, so the old ppid_$$ fallback used the hook's OWN pid and
+    # the PostToolUse write never matched the next PreToolUse read — the cache
+    # silently never hit and "don't ask again" re-prompted forever. This drives
+    # post-fetch (write) and validate-fetch (read) as SEPARATE processes sharing
+    # only the ambient session id.
+    if [ -f "$POST_FETCH" ]; then
+        _e2e_sid="e2e-session-$$-$(date +%s)"
+        _e2e_cache_file="${TMPDIR:-/tmp}/cc-session-allowed-domains-${_e2e_sid}"
+        rm -f "$_e2e_cache_file"
+
+        # Process 1: post-fetch caches the domain (CLAUDE_SESSION_KEY unset)
+        echo "$(mock_fetch_json "https://e2e-domain.example.org/x")" | \
+            env -u CLAUDE_SESSION_KEY CLAUDE_PROJECT_DIR=/tmp \
+            CLAUDE_CODE_SESSION_ID="$_e2e_sid" \
+            bash "$POST_FETCH" 2>/dev/null
+
+        # Process 2: validate-fetch must now find the cache and NOT ask
+        output=$(echo "$(mock_fetch_json "https://e2e-domain.example.org/x")" | \
+            env -u CLAUDE_SESSION_KEY CLAUDE_PROJECT_DIR=/tmp \
+            CLAUDE_CODE_SESSION_ID="$_e2e_sid" \
+            bash "$VALIDATE_FETCH" 2>/dev/null) || true
+        if [ -z "$output" ] || ! echo "$output" | grep -q '"ask"\|"deny"'; then
+            _pass "fetch: cross-process cache hit via CLAUDE_CODE_SESSION_ID"
+        else
+            _fail "fetch: cross-process cache should hit without CLAUDE_SESSION_KEY" "$output"
+        fi
+        rm -f "$_e2e_cache_file"
+    fi
+
     # Cleanup session cache test files
     rm -f "$_test_cache_file"
     rm -f "${TMPDIR:-/tmp}/cc-session-allowed-domains-${_other_session_key}"


### PR DESCRIPTION
Closes #310.

## Problem
The WebFetch domain-confirmation prompt re-appeared for the **same domain** on every fetch — even after choosing "Yes, and don't ask again". Hit while a `deep-research` workflow kept re-prompting for `ares.gov.cz`.

## Root cause
`_cc_session_cache_file()` keyed the cache on `CLAUDE_SESSION_KEY` (always **unset** in production — Claude Code exports `CLAUDE_CODE_SESSION_ID`) and fell back to `ppid_$$` — the hook's **own** one-shot PID. Each hook is a fresh process, so the PostToolUse **write** and the next PreToolUse **read** keyed *different* files. Cache hit rate was structurally **0%**; the prompt always re-fired.

```
OLD fallback, two processes:  ppid_12015  vs  ppid_12023   -> never match
NEW key, two processes:       .../cc-session-allowed-domains-<sid>  (identical)
```

## Fix
```sh
local session_key="${CLAUDE_SESSION_KEY:-${CLAUDE_CODE_SESSION_ID:-ppid_$PPID}}"
```
Resolution order: explicit test override → real session id → persistent parent PID (matching the original comment's intent, not the ephemeral child PID). Backwards compatible — `CLAUDE_SESSION_KEY` still wins.

## Tests
New regression test in suite 06 drives **write and read as separate processes** with `CLAUDE_SESSION_KEY` unset (`env -u`), relying only on `CLAUDE_CODE_SESSION_ID` — the real production topology. Verified it **FAILS on the old code** (`77 passed, 1 failed`) and **PASSES on the fix** (`78 passed`). Prior tests masked the bug by always injecting `CLAUDE_SESSION_KEY`.

`bash tests/run-all.sh`: 23/25 suites pass. The two failures (`07-agent-permissions.sh`, `21-snapshot-regression.sh`) are **pre-existing on `main`** — confirmed by stashing this change and re-running; identical failures. Unrelated to this PR.

## Peer review (concurrency / reliability / security)
- **Concurrency:** parallel subagents append a sub-PIPE_BUF line under `O_APPEND` → atomic, no corruption. Check-then-append TOCTOU can at worst write a duplicate line, harmless under `grep -qxF`.
- **Reliability:** `TMPDIR` inherited identically by sibling hooks; graceful degradation to `ppid_$PPID` if both env vars are ever unset.
- **Security:** cross-session isolation preserved; strict mode still ignores the cache (allowlist never bypassed).

## Scope
hooks