### PR TITLE
fix(cicd): pr-merged respects approval gate, stops In-Progress bounce (#312)

### DIFF
--- a/.github/workflows/project-board-automation.yml
+++ b/.github/workflows/project-board-automation.yml
@@ -117,9 +117,12 @@ jobs:
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Move linked issues to Done
+      - name: Move linked issues (respects approval gate)
         env:
           GH_TOKEN: ${{ secrets.PROJECT_PAT }}
+          # When "true": a merged PR parks linked issues at To Be Tested for
+          # human /project-board approve. When "false": PR merge → Done (autonomous).
+          REQUIRE_HUMAN_APPROVAL: "true"
         run: |
           set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then exit 0; fi
@@ -135,6 +138,20 @@ jobs:
           if [ -z "$ISSUES" ]; then
             echo "No linked issues found in PR body"
             exit 0
+          fi
+
+          # Select target column based on the approval gate (#312). With the gate
+          # on, a merged PR must park the issue at To Be Tested for human approval,
+          # NOT slam it to Done — that bypassed the gate. This also removes the only
+          # "Done" writer in the merge path, so the issue-reopened job (which only
+          # acts on Done/Canceled) no longer races on a stale Done and bounces the
+          # card to In Progress after GitHub auto-closes the issue via "Closes #N".
+          if [ "$REQUIRE_HUMAN_APPROVAL" = "true" ]; then
+            TARGET_ID="$TESTING_ID"
+            TARGET_NAME="To Be Tested"
+          else
+            TARGET_ID="$DONE_ID"
+            TARGET_NAME="Done"
           fi
 
           ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 500 | tr -d '\000-\037') || {
@@ -161,13 +178,13 @@ jobs:
                 projectId: "'"$PROJECT_ID"'"
                 itemId: "'"$ITEM_ID"'"
                 fieldId: "'"$STATUS_FIELD_ID"'"
-                value: { singleSelectOptionId: "'"$DONE_ID"'" }
+                value: { singleSelectOptionId: "'"$TARGET_ID"'" }
               }) { projectV2Item { id } }
             }' || {
               echo "::warning::Board mutation failed for #$ISSUE_NUM (check PROJECT_PAT scopes or project permissions)"
               continue
             }
-            echo "Moved #$ISSUE_NUM → Done (PR merged)"
+            echo "Moved #$ISSUE_NUM → $TARGET_NAME (PR merged)"
           done
 
   # ── Issue assigned (from Backlog/Roadmap) → Todo ──


### PR DESCRIPTION
Closes #312.

## Problem
A merged PR with `Closes #N` left the issue **open in In Progress** instead of parked at To Be Tested for approval (observed on #310 and #256). Two interacting defects:

1. **Gate bypass:** the `pr-merged` job moved linked issues to **Done** via a hardcoded `DONE_ID`, ignoring `CC_REQUIRE_HUMAN_APPROVAL`.
2. **Race → In Progress:** because `pr-merged` was the only writer of `Done` in the merge path, the cascade after GitHub's auto-close raced:
   - GitHub auto-closes the issue (`Closes #N`) → `issues: closed`
   - `issue-closed` guard (criteria present, no `approved` label) → sets **To Be Tested** + **reopens** the issue
   - `issue-reopened` (acts only on `Done`/`Canceled`) reads the eventually-consistent board, catches `pr-merged`'s stale **Done**, and bounces the card to **In Progress**

## Fix
`pr-merged` now selects its target column by the gate:
```sh
if [ "$REQUIRE_HUMAN_APPROVAL" = "true" ]; then
  TARGET_ID="$TESTING_ID"; TARGET_NAME="To Be Tested"
else
  TARGET_ID="$DONE_ID"; TARGET_NAME="Done"
fi
```
This honors the approval gate **and** removes the only `Done` writer in the merge path — so `issue-reopened` never races on a stale `Done`, and a gate-passing merge settles correctly at **To Be Tested** (issue reopened by the guard, board = TBT).

The deployed `.github/workflows/` step now matches the framework template (`cicd/workflows/`), which was already gate-aware but had never been re-synced into this repo.

## Verification
- YAML validates (ruby `YAML.load_file`).
- Target-selection logic tested both ways: `true → To Be Tested (f8614c05)`, `false → Done (28f9eecd)`.
- **Live verification:** this PR closes #312 with the gate on, so on merge #312 itself should land in **To Be Tested** (not In Progress) — the first issue to flow through the fixed path.

## Scope / out of scope
- Scoped to the `pr-merged` step. The `issue-closed`/`issue-reopened` guards are already correct and untouched.
- Follow-ups noted, not addressed here: (a) `cicd/workflows/` template lacks the deployed file's silent-failure hardening (separate divergence); (b) `/project-board approve` closes without adding an `approved` label while the guard checks for it — works today but worth reconciling.

## Scope
cicd