### PR TITLE
fix(skills): approve flow adds 'approved' label before closing (#314)

### DIFF
--- a/core/skills/project-board/SKILL.md
+++ b/core/skills/project-board/SKILL.md
@@ -794,8 +794,19 @@ Human approval gate. Moves an issue from "To Be Tested" to "Done" after reviewin
 2. Verify evidence comment exists
 3. Check SOX guard (if enabled): compare approver with assignee
 4. Check dual approval (if enabled): count existing approval comments
-5. Close the issue with "Approved by @username" comment
-6. Move to Done on the board
+5. **Add the `approved` label** — REQUIRED before closing. The `issue-closed` CI guard
+   (`project-board-automation.yml`) reopens any closed issue that has acceptance-criteria
+   checkboxes but lacks this label, bouncing it back to "To Be Tested". Skipping this step
+   makes the approval silently revert seconds later.
+   ```bash
+   gh issue edit <N> --repo {{CC_GITHUB_REPO}} --add-label "approved"
+   ```
+6. Close the issue with an "Approved by @username" comment (the literal `Approved by @`
+   string also satisfies the local closure-guard hook in `validate-bash.sh`)
+7. Move to Done on the board
+
+> The `github` provider's `pb_board_approve` already adds the `approved` label atomically
+> before closing; the steps above document the same requirement for the manual flow.
 
 ### `blocked`
 


### PR DESCRIPTION
Closes #314.

## Problem
The `project-board` `approve` Flow in `core/skills/project-board/SKILL.md` closed an issue with an `Approved by @user` comment but never added the `approved` **label**. The `issue-closed` CI guard (`project-board-automation.yml`) reopens any closed issue that has acceptance-criteria checkboxes but lacks that label — so every manually-executed approval **silently bounced back to To Be Tested** seconds later.

Observed live on 2026-06-06: #310, #256, and #312 all reopened by CI after approval until the label was added by hand.

## Fix
Add an explicit step to the approve Flow: add the `approved` label **before** closing, with a note explaining the CI guard requires it and that the close comment's `Approved by @` string also satisfies the local closure-guard hook.

Also documents that the `github` provider's `pb_board_approve` (`providers/github.sh:~396`) already adds this label atomically — the manual flow now matches.

## Verification
- Suite 02 (skills) passes 64/64; `project-board/SKILL.md` frontmatter + structure valid.
- Behavior confirmed live this session: with the label, approvals stick (#310/#256/#312 now durably Closed+Done); without it, CI reopens them.

## Scope / notes
- `plugin/skills/project-board/SKILL.md` has **no `approve` section** (condensed variant), so no change there — noted on the issue as a separate divergence.
- The provider script was already correct; this is a docs/flow fix for the model-facing path.

## Scope
skills