### PR TITLE
feat(hooks): guard against credentials embedded in git remote URLs

### DIFF
--- a/.claude/hooks/validate-git-remote-secret.sh
+++ b/.claude/hooks/validate-git-remote-secret.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# cognitive-core hook: PreToolUse (Bash) + SessionStart
+# Guards against credentials embedded in git remote URLs, e.g.
+#   https://x-access-token:gho_XXXX@github.com/owner/repo.git
+# which leaks the token in plaintext (.git/config) and pushes it around.
+#
+# Two modes, selected by the stdin payload:
+#   - PreToolUse (a Bash command is present): DENY a git command that would
+#     embed a credential in a remote URL.
+#   - SessionStart (no command): AUDIT the repo's configured remotes and WARN
+#     (additionalContext) if one already carries a credential.
+#
+# All patterns use POSIX ERE (no \s, \b, \w) for macOS + Linux compatibility.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_lib.sh"
+_cc_load_config
+
+# A URL carries a credential when it has userinfo with a secret part
+# (scheme://user:secret@host) or a known token format.
+CRED_URL_RE='://[^/@[:space:]]+:[^/@[:space:]]+@'
+TOKEN_RE='(gh[opsu]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|x-access-token:)'
+
+_cc_has_embedded_cred() {
+    # $1 = text; returns 0 if a credential pattern is present.
+    printf '%s' "$1" | grep -qE "$CRED_URL_RE" && return 0
+    printf '%s' "$1" | grep -qE "$TOKEN_RE" && return 0
+    return 1
+}
+
+_cc_redact() {
+    # Scrub userinfo and bare token formats so a secret is never printed.
+    sed -E -e 's#://[^/@]+(:[^/@]+)?@#://<REDACTED>@#g' \
+           -e 's#(gh[opsu]_|github_pat_)[A-Za-z0-9_]{10,}#<REDACTED>#g'
+}
+
+INPUT=$(cat)
+CMD=$(printf '%s' "$INPUT" | _cc_json_get ".tool_input.command" || true)
+
+# ---- PreToolUse: a Bash command is present ----
+if [ -n "$CMD" ]; then
+    # Only police git commands that create or use a remote URL.
+    if printf '%s' "$CMD" | grep -qE '(^|[^[:alnum:]_])git([^[:alnum:]_]|$)' \
+       && printf '%s' "$CMD" | grep -qE 'remote[[:space:]]+(add|set-url)|[[:space:]]clone[[:space:]]|[[:space:]](push|fetch|pull)([[:space:]]|$)|config[[:space:]]+remote\.'; then
+        if _cc_has_embedded_cred "$CMD"; then
+            _cc_json_pretool_deny "Refusing: this git command embeds a credential in a remote URL (token or user:secret@). Never store a secret in .git/config - use SSH or a credential helper (e.g. 'gh auth setup-git'). If the token was exposed, revoke and rotate it."
+            exit 0
+        fi
+    fi
+    exit 0
+fi
+
+# ---- SessionStart: no command -> audit configured remotes (warn only) ----
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+findings=""
+while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    while IFS= read -r url; do
+        [ -z "$url" ] && continue
+        if _cc_has_embedded_cred "$url"; then
+            red=$(printf '%s' "$url" | _cc_redact)
+            findings="${findings}  - remote '${name}': ${red}"$'\n'
+        fi
+    done < <( { git remote get-url --all "$name" 2>/dev/null
+               git remote get-url --push --all "$name" 2>/dev/null; } | sort -u )
+done < <(git remote 2>/dev/null)
+
+if [ -n "$findings" ]; then
+    _cc_json_session_context "SECURITY: a credential is embedded in a git remote URL (.git/config). Remove it (use SSH or 'gh auth setup-git') and rotate the token:"$'\n'"${findings}"
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/setup-env.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-git-remote-secret.sh"
           }
         ]
       },
@@ -27,6 +31,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-bash.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-git-remote-secret.sh"
           }
         ]
       },

--- a/core/hooks/validate-git-remote-secret.sh
+++ b/core/hooks/validate-git-remote-secret.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# cognitive-core hook: PreToolUse (Bash) + SessionStart
+# Guards against credentials embedded in git remote URLs, e.g.
+#   https://x-access-token:gho_XXXX@github.com/owner/repo.git
+# which leaks the token in plaintext (.git/config) and pushes it around.
+#
+# Two modes, selected by the stdin payload:
+#   - PreToolUse (a Bash command is present): DENY a git command that would
+#     embed a credential in a remote URL.
+#   - SessionStart (no command): AUDIT the repo's configured remotes and WARN
+#     (additionalContext) if one already carries a credential.
+#
+# All patterns use POSIX ERE (no \s, \b, \w) for macOS + Linux compatibility.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_lib.sh"
+_cc_load_config
+
+# A URL carries a credential when it has userinfo with a secret part
+# (scheme://user:secret@host) or a known token format.
+CRED_URL_RE='://[^/@[:space:]]+:[^/@[:space:]]+@'
+TOKEN_RE='(gh[opsu]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|x-access-token:)'
+
+_cc_has_embedded_cred() {
+    # $1 = text; returns 0 if a credential pattern is present.
+    printf '%s' "$1" | grep -qE "$CRED_URL_RE" && return 0
+    printf '%s' "$1" | grep -qE "$TOKEN_RE" && return 0
+    return 1
+}
+
+_cc_redact() {
+    # Scrub userinfo and bare token formats so a secret is never printed.
+    sed -E -e 's#://[^/@]+(:[^/@]+)?@#://<REDACTED>@#g' \
+           -e 's#(gh[opsu]_|github_pat_)[A-Za-z0-9_]{10,}#<REDACTED>#g'
+}
+
+INPUT=$(cat)
+CMD=$(printf '%s' "$INPUT" | _cc_json_get ".tool_input.command" || true)
+
+# ---- PreToolUse: a Bash command is present ----
+if [ -n "$CMD" ]; then
+    # Only police git commands that create or use a remote URL.
+    if printf '%s' "$CMD" | grep -qE '(^|[^[:alnum:]_])git([^[:alnum:]_]|$)' \
+       && printf '%s' "$CMD" | grep -qE 'remote[[:space:]]+(add|set-url)|[[:space:]]clone[[:space:]]|[[:space:]](push|fetch|pull)([[:space:]]|$)|config[[:space:]]+remote\.'; then
+        if _cc_has_embedded_cred "$CMD"; then
+            _cc_json_pretool_deny "Refusing: this git command embeds a credential in a remote URL (token or user:secret@). Never store a secret in .git/config - use SSH or a credential helper (e.g. 'gh auth setup-git'). If the token was exposed, revoke and rotate it."
+            exit 0
+        fi
+    fi
+    exit 0
+fi
+
+# ---- SessionStart: no command -> audit configured remotes (warn only) ----
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+findings=""
+while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    while IFS= read -r url; do
+        [ -z "$url" ] && continue
+        if _cc_has_embedded_cred "$url"; then
+            red=$(printf '%s' "$url" | _cc_redact)
+            findings="${findings}  - remote '${name}': ${red}"$'\n'
+        fi
+    done < <( { git remote get-url --all "$name" 2>/dev/null
+               git remote get-url --push --all "$name" 2>/dev/null; } | sort -u )
+done < <(git remote 2>/dev/null)
+
+if [ -n "$findings" ]; then
+    _cc_json_session_context "SECURITY: a credential is embedded in a git remote URL (.git/config). Remove it (use SSH or 'gh auth setup-git') and rotate the token:"$'\n'"${findings}"
+fi
+exit 0

--- a/core/templates/settings.json.tmpl
+++ b/core/templates/settings.json.tmpl
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/setup-env.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-git-remote-secret.sh"
           }
         ]
       },
@@ -31,6 +35,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-bash.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/validate-git-remote-secret.sh"
           }
         ]
       },

--- a/install.sh
+++ b/install.sh
@@ -270,7 +270,7 @@ else
     prompt_default CC_SKILLS "Skills to install" "session-resume skill-sync code-review pre-commit fitness project-status project-board acceptance-verification security-baseline"
 
     # Hooks
-    prompt_default CC_HOOKS "Hooks to enable" "session-guard setup-env compact-reminder validate-bash validate-read validate-fetch validate-write post-edit-lint notify-complete session-cleanup"
+    prompt_default CC_HOOKS "Hooks to enable" "session-guard setup-env compact-reminder validate-bash validate-git-remote-secret validate-read validate-fetch validate-write post-edit-lint notify-complete session-cleanup"
 
     # Auto-append language-specific version guard hooks
     case "${CC_LANGUAGE:-}" in

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup-env.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-git-remote-secret.sh"
           }
         ]
       },
@@ -36,6 +40,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-bash.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/validate-git-remote-secret.sh"
           }
         ]
       },

--- a/plugin/scripts/validate-git-remote-secret.sh
+++ b/plugin/scripts/validate-git-remote-secret.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# cognitive-core hook: PreToolUse (Bash) + SessionStart
+# Guards against credentials embedded in git remote URLs, e.g.
+#   https://x-access-token:gho_XXXX@github.com/owner/repo.git
+# which leaks the token in plaintext (.git/config) and pushes it around.
+#
+# Two modes, selected by the stdin payload:
+#   - PreToolUse (a Bash command is present): DENY a git command that would
+#     embed a credential in a remote URL.
+#   - SessionStart (no command): AUDIT the repo's configured remotes and WARN
+#     (additionalContext) if one already carries a credential.
+#
+# All patterns use POSIX ERE (no \s, \b, \w) for macOS + Linux compatibility.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_lib.sh"
+_cc_load_config
+
+# A URL carries a credential when it has userinfo with a secret part
+# (scheme://user:secret@host) or a known token format.
+CRED_URL_RE='://[^/@[:space:]]+:[^/@[:space:]]+@'
+TOKEN_RE='(gh[opsu]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|x-access-token:)'
+
+_cc_has_embedded_cred() {
+    # $1 = text; returns 0 if a credential pattern is present.
+    printf '%s' "$1" | grep -qE "$CRED_URL_RE" && return 0
+    printf '%s' "$1" | grep -qE "$TOKEN_RE" && return 0
+    return 1
+}
+
+_cc_redact() {
+    # Scrub userinfo and bare token formats so a secret is never printed.
+    sed -E -e 's#://[^/@]+(:[^/@]+)?@#://<REDACTED>@#g' \
+           -e 's#(gh[opsu]_|github_pat_)[A-Za-z0-9_]{10,}#<REDACTED>#g'
+}
+
+INPUT=$(cat)
+CMD=$(printf '%s' "$INPUT" | _cc_json_get ".tool_input.command" || true)
+
+# ---- PreToolUse: a Bash command is present ----
+if [ -n "$CMD" ]; then
+    # Only police git commands that create or use a remote URL.
+    if printf '%s' "$CMD" | grep -qE '(^|[^[:alnum:]_])git([^[:alnum:]_]|$)' \
+       && printf '%s' "$CMD" | grep -qE 'remote[[:space:]]+(add|set-url)|[[:space:]]clone[[:space:]]|[[:space:]](push|fetch|pull)([[:space:]]|$)|config[[:space:]]+remote\.'; then
+        if _cc_has_embedded_cred "$CMD"; then
+            _cc_json_pretool_deny "Refusing: this git command embeds a credential in a remote URL (token or user:secret@). Never store a secret in .git/config - use SSH or a credential helper (e.g. 'gh auth setup-git'). If the token was exposed, revoke and rotate it."
+            exit 0
+        fi
+    fi
+    exit 0
+fi
+
+# ---- SessionStart: no command -> audit configured remotes (warn only) ----
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+findings=""
+while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    while IFS= read -r url; do
+        [ -z "$url" ] && continue
+        if _cc_has_embedded_cred "$url"; then
+            red=$(printf '%s' "$url" | _cc_redact)
+            findings="${findings}  - remote '${name}': ${red}"$'\n'
+        fi
+    done < <( { git remote get-url --all "$name" 2>/dev/null
+               git remote get-url --push --all "$name" 2>/dev/null; } | sort -u )
+done < <(git remote 2>/dev/null)
+
+if [ -n "$findings" ]; then
+    _cc_json_session_context "SECURITY: a credential is embedded in a git remote URL (.git/config). Remove it (use SSH or 'gh auth setup-git') and rotate the token:"$'\n'"${findings}"
+fi
+exit 0

--- a/tests/suites/06-security-hooks.sh
+++ b/tests/suites/06-security-hooks.sh
@@ -695,4 +695,41 @@ else
     _skip "setup-env.sh not found"
 fi
 
+# ===== validate-git-remote-secret.sh: credentials in git remote URLs =====
+GIT_REMOTE_SECRET="${HOOKS_DIR}/validate-git-remote-secret.sh"
+
+if [ -f "$GIT_REMOTE_SECRET" ]; then
+    assert_hook_denies \
+        "git-remote-secret: token in remote set-url -> deny" \
+        "$GIT_REMOTE_SECRET" \
+        "$(mock_bash_json "git remote set-url origin https://x-access-token:gho_AAAAAAAAAAAAAAAAAAAAAAAA@github.com/x/y.git")"
+
+    assert_hook_denies \
+        "git-remote-secret: user:pass clone -> deny" \
+        "$GIT_REMOTE_SECRET" \
+        "$(mock_bash_json "git clone https://user:s3cr3tpass@github.com/x/y.git")"
+
+    assert_hook_denies \
+        "git-remote-secret: ghp token in push url -> deny" \
+        "$GIT_REMOTE_SECRET" \
+        "$(mock_bash_json "git push https://ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@github.com/x/y.git main")"
+
+    assert_hook_allows \
+        "git-remote-secret: clean git push -> allow" \
+        "$GIT_REMOTE_SECRET" \
+        "$(mock_bash_json "git push origin main")"
+
+    assert_hook_allows \
+        "git-remote-secret: clean clone -> allow" \
+        "$GIT_REMOTE_SECRET" \
+        "$(mock_bash_json "git clone https://github.com/x/y.git")"
+
+    assert_hook_allows \
+        "git-remote-secret: non-git command with token -> allow (scoped to git)" \
+        "$GIT_REMOTE_SECRET" \
+        "$(mock_bash_json "echo https://x-access-token:gho_AAAAAAAAAAAAAAAAAAAAAAAA@github.com")"
+else
+    _skip "validate-git-remote-secret.sh not found"
+fi
+
 suite_end


### PR DESCRIPTION
Adds a framework-wide guard against the failure mode where a credential gets baked into a git remote URL (`https://x-access-token:gho_…@github.com/…`) — which leaks the token in plaintext `.git/config`. Motivated by a real `gh` OAuth token found embedded in a downstream repo's remote (since rotated).

## What it does
`core/hooks/validate-git-remote-secret.sh` — one hook, two events:
- **PreToolUse (Bash):** denies a git command (`remote add/set-url`, `clone`, `push/fetch/pull`, `config remote.*`) that embeds a credential in a URL. Prevents an agent from creating the leak. Scoped to git; non-git commands pass.
- **SessionStart:** audits the repo's configured remotes (fetch **and** push URLs) and emits a redacted `SECURITY:` warning if one already carries a credential — catches a token sitting in `.git/config` before it's pushed.

Detection: provider-agnostic `user:secret@` plus GitHub token formats (`gh{o,p,s,u}_`, `github_pat_`, `x-access-token`). Output is always redacted.

## Wiring
- `core/templates/settings.json.tmpl` + framework `.claude/settings.json` (SessionStart + PreToolUse/Bash)
- `plugin/hooks/hooks.json` + `plugin/scripts/` mirror; `.claude/hooks/` dogfood copy
- `install.sh` default `CC_HOOKS` list

## Tests
6 cases added to `tests/suites/06-security-hooks.sh` (deny: token set-url, user:pass clone, ghp push-url; allow: clean push, clean clone, non-git-with-token). Suites: **06 84/84**, **01 shellcheck 70/70**, **13 plugin-structure 123/123**.

## Notes
Defense-in-depth — the PreToolUse gate only covers agent-run commands and the SessionStart audit is advisory; pair with server-side secret scanning / push protection. `build-plugin.sh` was NOT run to regenerate `plugin/` (it has a pre-existing BSD/macOS `sed` bug that half-rebuilds the dir); the plugin script + hooks.json were updated by hand instead — CI/Linux regen will reconcile.